### PR TITLE
Prince/ Export CSS tokens

### DIFF
--- a/lib/styles/index.scss
+++ b/lib/styles/index.scss
@@ -1,7 +1,7 @@
 /* Global Styles */
 @import "@quill/color.scss";
 @import "@quill/opacity.scss";
-@import '@quill/color.opacity.scss';
+@import "@quill/color.opacity.scss";
 @import "@quill/color.semantic.scss";
 @import "./reset.scss";
 
@@ -50,51 +50,50 @@
         &--primary-coral {
             background-color: var(--core-color-solid-coral-700);
             color: var(--core-color-solid-slate-50);
-            fill:  var(--core-color-solid-slate-50);
+            fill: var(--core-color-solid-slate-50);
             border: none;
-            &:hover:not(:disabled){
+            &:hover:not(:disabled) {
                 background-color: var(--core-color-solid-coral-800);
             }
-            &:active:not(:disabled){
+            &:active:not(:disabled) {
                 background-color: var(--core-color-solid-coral-900);
             }
-            &:disabled{
+            &:disabled {
                 opacity: var(--core-opacity-600);
             }
         }
-        &--primary-black{
+        &--primary-black {
             background-color: var(--core-color-solid-slate-1400);
             color: var(--core-color-solid-slate-50);
             fill: var(--core-color-solid-slate-50);
             border: none;
-            &:hover:not(:disabled){
+            &:hover:not(:disabled) {
                 background-color: var(--core-color-opacity-black-700);
             }
-            &:active:not(:disabled){
+            &:active:not(:disabled) {
                 background-color: var(--core-color-opacity-black-800);
             }
-            &:disabled{
+            &:disabled {
                 opacity: var(--core-opacity-600);
-              
             }
         }
-        &--primary-white{
+        &--primary-white {
             background-color: var(--core-color-solid-slate-50);
             color: var(--core-color-solid-slate-1400);
             fill: var(--core-color-solid-slate-1400);
             border: none;
-            &:hover:not(:disabled){
+            &:hover:not(:disabled) {
                 background-color: var(--core-color-opacity-white-800);
             }
-            &:active:not(:disabled){
+            &:active:not(:disabled) {
                 background-color: var(--core-color-opacity-white-700);
             }
-            &:disabled{
+            &:disabled {
                 opacity: var(--core-opacity-600);
             }
         }
         &--primary-purchase {
-            background-color : var(--core-color-solid-emerald-700);
+            background-color: var(--core-color-solid-emerald-700);
             color: var(--core-color-solid-slate-50);
             fill: var(--core-color-solid-slate-50);
             border: none;
@@ -104,7 +103,7 @@
             &:active:not(:disabled) {
                 background-color: var(--core-color-solid-emerald-900);
             }
-            &:disabled{
+            &:disabled {
                 opacity: var(--core-opacity-600);
             }
         }
@@ -119,76 +118,76 @@
             &:active:not(:disabled) {
                 background-color: var(--core-color-solid-cherry-900);
             }
-            &:disabled{
+            &:disabled {
                 opacity: var(--core-opacity-600);
             }
         }
         &--secondary-coral {
-            background-color :transparent;
+            background-color: transparent;
             border-style: solid;
             border-color: var(--core-color-solid-coral-700);
-            color:  var(--core-color-solid-coral-700);
+            color: var(--core-color-solid-coral-700);
             fill: var(--core-color-solid-coral-700);
-            &:hover:not(:disabled){
+            &:hover:not(:disabled) {
                 background-color: var(--core-color-opacity-coral-100);
             }
-            &:active:not(:disabled){
+            &:active:not(:disabled) {
                 background-color: var(--core-color-opacity-coral-200);
             }
-            &:disabled{
+            &:disabled {
                 opacity: var(--core-opacity-600);
             }
         }
-        &--secondary-black{
-            background-color:transparent;
+        &--secondary-black {
+            background-color: transparent;
             border-style: solid;
             border-color: var(--core-color-solid-black-1400);
-            color:  var(--core-color-solid-black-1400);
-            fill:  var(--core-color-solid-black-1400);
-            &:hover:not(:disabled){
+            color: var(--core-color-solid-black-1400);
+            fill: var(--core-color-solid-black-1400);
+            &:hover:not(:disabled) {
                 background-color: var(--core-color-opacity-black-100);
             }
-            &:active:not(:disabled){
+            &:active:not(:disabled) {
                 background-color: var(--core-color-opacity-black-200);
             }
-            &:disabled{
+            &:disabled {
                 opacity: var(--core-opacity-600);
             }
         }
-        &--secondary-white{
-            background-color:transparent;
+        &--secondary-white {
+            background-color: transparent;
             border-style: solid;
             border-color: var(--core-color-solid-slate-50);
-            color:  var(--core-color-solid-slate-50);
-            fill:  var(--core-color-solid-slate-50);
-            &:hover:not(:disabled){
+            color: var(--core-color-solid-slate-50);
+            fill: var(--core-color-solid-slate-50);
+            &:hover:not(:disabled) {
                 background-color: var(--core-color-opacity-white-200);
             }
-            &:active:not(:disabled){
+            &:active:not(:disabled) {
                 background-color: var(--core-color-opacity-white-100);
             }
-            &:disabled{
+            &:disabled {
                 opacity: var(--core-opacity-600);
             }
         }
         &--secondary-purchase {
-            background-color :transparent;
+            background-color: transparent;
             border-style: solid;
             border-color: var(--core-color-solid-emerald-700);
             color: var(--core-color-solid-emerald-700);
             fill: var(--core-color-solid-emerald-700);
             &:hover:not(:disabled) {
-                background-color:var(--core-color-solid-emerald-100);
+                background-color: var(--core-color-solid-emerald-100);
             }
             &:active:not(:disabled) {
                 background-color: var(--core-color-opacity-emerald-200);
             }
-            &:disabled{
+            &:disabled {
                 opacity: var(--core-opacity-600);
             }
         }
-        &--secondary-sell{
-            background-color :transparent;
+        &--secondary-sell {
+            background-color: transparent;
             border-style: solid;
             border-color: var(--core-color-solid-cherry-700);
             color: var(--core-color-solid-cherry-700);
@@ -199,60 +198,60 @@
             &:active:not(:disabled) {
                 background-color: var(--core-color-opacity-cherry-200);
             }
-            &:disabled{
+            &:disabled {
                 opacity: var(--core-opacity-600);
             }
         }
-        &--tertiary-coral{
-            background-color :transparent;
+        &--tertiary-coral {
+            background-color: transparent;
             color: var(--core-color-solid-coral-700);
             fill: var(--core-color-solid-coral-700);
             text-decoration: underline;
             border: none;
-            &:hover:not(:disabled){
+            &:hover:not(:disabled) {
                 background-color: var(--core-color-opacity-coral-100);
             }
-            &:active:not(:disabled){
+            &:active:not(:disabled) {
                 background-color: var(--core-color-opacity-coral-200);
             }
-            &:disabled{
+            &:disabled {
                 opacity: var(--core-opacity-600);
             }
         }
-        &--tertiary-black{
-            background-color :transparent;
+        &--tertiary-black {
+            background-color: transparent;
             color: var(--core-color-solid-black-1400);
             fill: var(--core-color-solid-black-1400);
             text-decoration: underline;
             border: none;
-            &:hover:not(:disabled){
+            &:hover:not(:disabled) {
                 background-color: var(--core-color-opacity-black-100);
             }
-            &:active:not(:disabled){
+            &:active:not(:disabled) {
                 background-color: var(--core-color-opacity-black-200);
             }
-            &:disabled{
+            &:disabled {
                 opacity: var(--core-opacity-600);
             }
         }
-        &--tertiary-white{
-            background-color :transparent;
+        &--tertiary-white {
+            background-color: transparent;
             color: var(--core-color-solid-slate-50);
             fill: var(--core-color-solid-slate-50);
             text-decoration: underline;
             border: none;
-            &:hover:not(:disabled){
+            &:hover:not(:disabled) {
                 background-color: var(--core-color-opacity-white-200);
             }
-            &:active:not(:disabled){
+            &:active:not(:disabled) {
                 background-color: var(--core-color-opacity-white-100);
             }
-            &:disabled{
+            &:disabled {
                 opacity: var(--core-opacity-600);
             }
         }
-        &--tertiary-purchase{
-            background-color :transparent;
+        &--tertiary-purchase {
+            background-color: transparent;
             color: var(--core-color-solid-emerald-700);
             fill: var(--core-color-solid-emerald-700);
             text-decoration: underline;
@@ -263,12 +262,12 @@
             &:active:not(:disabled) {
                 background-color: var(--core-color-opacity-emerald-200);
             }
-            &:disabled{
+            &:disabled {
                 opacity: var(--core-opacity-600);
             }
         }
-        &--tertiary-sell{
-            background-color :transparent;
+        &--tertiary-sell {
+            background-color: transparent;
             color: var(--core-color-solid-cherry-700);
             fill: var(--core-color-solid-cherry-700);
             text-decoration: underline;
@@ -279,11 +278,9 @@
             &:active:not(:disabled) {
                 background-color: var(--core-color-opacity-cherry-200);
             }
-            &:disabled{
+            &:disabled {
                 opacity: var(--core-opacity-600);
             }
         }
-   
     }
-
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     },
     "scripts": {
         "dev": "vite --port 4321 --open",
-        "build": "tsc -p ./tsconfig-build.json && vite build",
+        "build": "tsc -p ./tsconfig-build.json && vite build && npm run generate:styles",
         "prepublish": "npm run build",
         "generate:styles": "node scripts/transformer.js &&  npx prettier --write lib/styles",
         "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",

--- a/scripts/transformer.js
+++ b/scripts/transformer.js
@@ -148,7 +148,10 @@ class Transformer {
                 fileName,
             );
 
-            const filePaths = [`lib/styles/quill/${fileName}.scss`];
+            const filePaths = [
+                `lib/styles/quill/${fileName}.scss`,
+                `dist/quill/${fileName}.scss`,
+            ];
 
             filePaths.map((item) => {
                 const dirPath = path.dirname(item);

--- a/scripts/transformer.js
+++ b/scripts/transformer.js
@@ -150,7 +150,7 @@ class Transformer {
 
             const filePaths = [
                 `lib/styles/quill/${fileName}.scss`,
-                `dist/quill/${fileName}.scss`,
+                `dist/quill/${fileName}.css`,
             ];
 
             filePaths.map((item) => {


### PR DESCRIPTION
- This will allow consumers to use `Quill Design tokens` on their projects. 
- We are looking at the possibility of using this as `tailwind` custom configuration.
- Refactored the `transformer` to perform more accurate resolution of token variables during css file creation. 