### PR TITLE
Jia/_/textfield-fix

### DIFF
--- a/lib/components/Input/base/__tests__/__snapshots__/base.test.tsx.snap
+++ b/lib/components/Input/base/__tests__/__snapshots__/base.test.tsx.snap
@@ -70,6 +70,11 @@ exports[`Input should render an Input with a label 1`] = `
           for="UserName"
         >
           UserName
+          <div
+            class="label-field-marker label-field-marker__required--false"
+          >
+            (optional)
+          </div>
         </label>
       </div>
     </div>

--- a/lib/components/Input/base/__tests__/__snapshots__/base.test.tsx.snap
+++ b/lib/components/Input/base/__tests__/__snapshots__/base.test.tsx.snap
@@ -8,10 +8,14 @@ exports[`Input should render a default Input 1`] = `
     <div
       class="quill-input__wrapper quill-input__wrapper__variant--outline quill-input__wrapper__size--md quill-input__wrapper__status--neutral"
     >
-      <input
-        class="input peer input__align--left input__size--md"
-        type="text"
-      />
+      <div
+        class="quill-input-label__wrapper"
+      >
+        <input
+          class="input peer input__align--left input__size--md"
+          type="text"
+        />
+      </div>
     </div>
     <div
       class="message__container"
@@ -28,11 +32,15 @@ exports[`Input should render a disabled Input with a variant of fill 1`] = `
     <div
       class="quill-input__wrapper quill-input__wrapper__variant--fill status--neutral quill-input__wrapper__size--md quill-input__wrapper__status--neutral"
     >
-      <input
-        class="input peer input__align--left input__size--md"
-        disabled=""
-        type="text"
-      />
+      <div
+        class="quill-input-label__wrapper"
+      >
+        <input
+          class="input peer input__align--left input__size--md"
+          disabled=""
+          type="text"
+        />
+      </div>
     </div>
     <div
       class="message__container"
@@ -49,17 +57,21 @@ exports[`Input should render an Input with a label 1`] = `
     <div
       class="quill-input__wrapper quill-input__wrapper__variant--outline quill-input__wrapper__size--md quill-input__wrapper__status--neutral"
     >
-      <input
-        class="input peer input__align--left input__size--md"
-        id="UserName"
-        type="text"
-      />
-      <label
-        class="label label__status--neutral"
-        for="UserName"
+      <div
+        class="quill-input-label__wrapper"
       >
-        UserName
-      </label>
+        <input
+          class="input peer input__align--left input__size--md"
+          id="UserName"
+          type="text"
+        />
+        <label
+          class="label label__status--neutral"
+          for="UserName"
+        >
+          UserName
+        </label>
+      </div>
     </div>
     <div
       class="message__container"
@@ -76,10 +88,14 @@ exports[`Input should render an Input with a variant of outline 1`] = `
     <div
       class="quill-input__wrapper quill-input__wrapper__variant--outline quill-input__wrapper__size--md quill-input__wrapper__status--neutral"
     >
-      <input
-        class="input peer input__align--left input__size--md"
-        type="text"
-      />
+      <div
+        class="quill-input-label__wrapper"
+      >
+        <input
+          class="input peer input__align--left input__size--md"
+          type="text"
+        />
+      </div>
     </div>
     <div
       class="message__container"
@@ -96,10 +112,14 @@ exports[`Input should render an Input with centered text 1`] = `
     <div
       class="quill-input__wrapper quill-input__wrapper__variant--outline quill-input__wrapper__size--md quill-input__wrapper__status--neutral"
     >
-      <input
-        class="input peer input__align--center input__size--md"
-        type="text"
-      />
+      <div
+        class="quill-input-label__wrapper"
+      >
+        <input
+          class="input peer input__align--center input__size--md"
+          type="text"
+        />
+      </div>
     </div>
     <div
       class="message__container"
@@ -116,10 +136,14 @@ exports[`Input should render an Input with status messages 1`] = `
     <div
       class="quill-input__wrapper quill-input__wrapper__variant--outline quill-input__wrapper__size--md quill-input__wrapper__status--neutral"
     >
-      <input
-        class="input peer input__align--left input__size--md"
-        type="text"
-      />
+      <div
+        class="quill-input-label__wrapper"
+      >
+        <input
+          class="input peer input__align--left input__size--md"
+          type="text"
+        />
+      </div>
     </div>
     <div
       class="message__container"

--- a/lib/components/Input/base/__tests__/__snapshots__/base.test.tsx.snap
+++ b/lib/components/Input/base/__tests__/__snapshots__/base.test.tsx.snap
@@ -1,5 +1,41 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Input should render a Input with field marker 1`] = `
+<div>
+  <div
+    class="quill-input__container"
+  >
+    <div
+      class="quill-input__wrapper quill-input__wrapper__variant--fill status--neutral quill-input__wrapper__size--md quill-input__wrapper__status--neutral"
+    >
+      <div
+        class="quill-input-label__wrapper"
+      >
+        <input
+          class="input peer input__align--left input__size--md"
+          id="label"
+          type="text"
+        />
+        <label
+          class="label label__status--neutral"
+          for="label"
+        >
+          label
+          <div
+            class="label-field-marker label-field-marker__required--false"
+          >
+            (optional)
+          </div>
+        </label>
+      </div>
+    </div>
+    <div
+      class="message__container"
+    />
+  </div>
+</div>
+`;
+
 exports[`Input should render a default Input 1`] = `
 <div>
   <div

--- a/lib/components/Input/base/__tests__/base.test.tsx
+++ b/lib/components/Input/base/__tests__/base.test.tsx
@@ -37,4 +37,11 @@ describe("Input", () => {
         const { container } = render(<Input disabled variant="fill" />);
         expect(container).toMatchSnapshot();
     });
+
+    it("should render a Input with field marker", () => {
+        const { container } = render(
+            <Input label="label" fieldMarker={true} variant="fill" />,
+        );
+        expect(container).toMatchSnapshot();
+    });
 });

--- a/lib/components/Input/base/base.scss
+++ b/lib/components/Input/base/base.scss
@@ -64,6 +64,23 @@
         }
     }
 
+    &-label__wrapper {
+        display: flex;
+        flex-direction: column;
+        position: relative;
+
+        &:focus-within {
+            &:has(label) {
+                padding-top: var(--core-spacing-600);
+            }
+        }
+        &--has-value {
+            &:has(label) {
+                padding-top: var(--core-spacing-600);
+            }
+        }
+    }
+
     &__wrapper {
         width: 100%;
         display: inline-flex;
@@ -83,16 +100,6 @@
             transition-property: border;
             transition-timing-function: var(--core-motion-ease-400);
             transition-duration: var(--core-motion-duration-200);
-        }
-        &:focus-within {
-            &:has(label) {
-                padding-top: var(--core-spacing-600);
-            }
-        }
-        &--has-value {
-            &:has(label) {
-                padding-top: var(--core-spacing-600);
-            }
         }
         &__variant {
             &--fill {
@@ -147,6 +154,7 @@
         &__status {
             &--neutral {
                 color: var(--core-color-opacity-black-100);
+                background-color: var(--core-color-solid-slate-50);
                 &:focus-within {
                     border-color: var(--semantic-color-typography-prominent);
                     color: var(--semantic-color-typography-prominent);
@@ -220,6 +228,7 @@
             &:disabled {
                 color: var(--semantic-color-typography-disabled);
             }
+
             &:has(~ label) {
                 font-size: var(--core-fontSize-100);
                 &::placeholder {
@@ -231,6 +240,7 @@
                     }
                 }
             }
+
             &::-webkit-search-decoration,
             &::-webkit-search-cancel-button,
             &::-webkit-search-results-button,
@@ -257,9 +267,15 @@
             &__size {
                 &--sm {
                     height: var(--core-size-1100);
+                    font-size: var(
+                        --semantic-typography-body-sm-regular-default-fontSize
+                    );
                 }
                 &--md {
                     height: var(--core-size-1200);
+                    font-size: var(
+                        --semantic-typography-body-md-regular-default-fontSize
+                    );
                 }
             }
         }
@@ -272,10 +288,8 @@
             align-items: center;
             width: 100%;
             cursor: pointer;
+            left: var(--core-spacing-50);
 
-            &__hasIcon {
-                left: var(--core-spacing-2000);
-            }
             &__status {
                 &--neutral {
                     color: var(--core-color-opacity-black-600);
@@ -298,7 +312,7 @@
                 transform: translateY(-100%);
                 line-height: var(--core-lineHeight-100);
                 font-size: var(--core-fontSize-50);
-                height: var(--core-size-900);
+                height: var(--core-size-600);
                 gap: var(--semantic-spacing-gap-sm);
             }
             &:not(placeholder-shown) + .label {

--- a/lib/components/Input/base/base.scss
+++ b/lib/components/Input/base/base.scss
@@ -59,8 +59,7 @@
         }
 
         .icon_wrapper {
-            width: var(--core-size-1200);
-            height: var(--core-size-1200);
+            display: flex;
         }
     }
 
@@ -68,6 +67,7 @@
         display: flex;
         flex-direction: column;
         position: relative;
+        flex-grow: 1;
 
         &:focus-within {
             &:has(label) {
@@ -92,6 +92,8 @@
         overflow: hidden;
         position: relative;
         border-style: solid;
+        display: flex;
+        gap: var(--semantic-spacing-gap-md);
 
         &:has(input:disabled) {
             cursor: not-allowed;
@@ -103,6 +105,12 @@
         }
         &__variant {
             &--fill {
+                background-color: var(--core-color-opacity-black-75);
+
+                &:hover {
+                    background-color: var(--core-color-opacity-black-100);
+                }
+
                 &:focus-within {
                     background-color: var(--core-color-opacity-black-75);
                     color: var(--semantic-color-typography-prominent);
@@ -154,7 +162,6 @@
         &__status {
             &--neutral {
                 color: var(--core-color-opacity-black-100);
-                background-color: var(--core-color-solid-slate-50);
                 &:focus-within {
                     border-color: var(--semantic-color-typography-prominent);
                     color: var(--semantic-color-typography-prominent);
@@ -289,6 +296,7 @@
             width: 100%;
             cursor: pointer;
             left: var(--core-spacing-50);
+            gap: var(--semantic-spacing-gap-sm);
 
             &__status {
                 &--neutral {
@@ -299,6 +307,18 @@
                 }
                 &--error {
                     color: var(--core-color-opacity-red-900);
+                }
+            }
+
+            &-field-marker {
+                &__required {
+                    &--true {
+                        color: var(--core-color-solid-red-900);
+                    }
+
+                    &--false {
+                        color: var(--semantic-color-typography-disabled);
+                    }
                 }
             }
         }
@@ -314,12 +334,24 @@
                 font-size: var(--core-fontSize-50);
                 height: var(--core-size-600);
                 gap: var(--semantic-spacing-gap-sm);
+
+                &-field-marker {
+                    font-size: var(
+                        --semantic-typography-caption-regular-default-fontSize
+                    );
+                }
             }
             &:not(placeholder-shown) + .label {
                 transform: translateY(-100%);
                 line-height: var(--core-lineHeight-100);
                 font-size: var(--core-fontSize-50);
                 height: var(--core-size-900);
+
+                &-field-marker {
+                    font-size: var(
+                        --semantic-typography-body-md-regular-default-fontSize
+                    );
+                }
             }
         }
 

--- a/lib/components/Input/base/index.tsx
+++ b/lib/components/Input/base/index.tsx
@@ -3,7 +3,7 @@ import { InputHTMLAttributes, ReactNode, forwardRef, useState } from "react";
 import "./base.scss";
 import React from "react";
 import { TMediumSizes } from "@types";
-import { CaptionText } from "@components/Typography";
+import { CaptionText, Text } from "@components/Typography";
 
 export type Variants = "fill" | "outline";
 export type Status = "neutral" | "success" | "error";
@@ -23,6 +23,7 @@ export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
     textAlignment?: TextAlignments;
     label?: ReactNode;
     value?: string;
+    fieldMarker?: boolean;
 }
 
 const statusIconColors = {
@@ -47,6 +48,8 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
             label,
             statusIcon: StatusIcon,
             onChange,
+            fieldMarker = true,
+            required = false,
             ...rest
         },
         ref,
@@ -70,6 +73,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
                     <div className="quill-input-label__wrapper">
                         <input
                             {...rest}
+                            required={required}
                             type={type}
                             className={clsx(
                                 "input",
@@ -95,6 +99,16 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
                                 htmlFor={label.toString()}
                             >
                                 {label}
+                                {fieldMarker && (
+                                    <div
+                                        className={clsx(
+                                            "label-field-marker",
+                                            `label-field-marker__required--${required}`,
+                                        )}
+                                    >
+                                        {required ? "*" : "(optional)"}
+                                    </div>
+                                )}
                             </label>
                         )}
                     </div>

--- a/lib/components/Input/base/index.tsx
+++ b/lib/components/Input/base/index.tsx
@@ -12,8 +12,8 @@ export type TextAlignments = "left" | "center";
 
 export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
     type?: Types;
-    icon?: ReactNode;
-    statusIcon?: ReactNode;
+    leftIcon?: ReactNode;
+    rightIcon?: ReactNode;
     inputSize?: TMediumSizes;
     status?: Status;
     disabled?: boolean;
@@ -41,12 +41,12 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
             status = "neutral",
             disabled = false,
             variant = "outline",
-            icon: Icon,
+            leftIcon,
             leftStatusMessage,
             rightStatusMessage,
             textAlignment = "left",
             label,
-            statusIcon: StatusIcon,
+            rightIcon,
             onChange,
             fieldMarker = true,
             required = false,
@@ -69,7 +69,9 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
                         `quill-input__wrapper__status--${status}`,
                     )}
                 >
-                    {Icon && <span className="icon_wrapper">{Icon}</span>}
+                    {leftIcon && (
+                        <span className="icon_wrapper">{leftIcon}</span>
+                    )}
                     <div className="quill-input-label__wrapper">
                         <input
                             {...rest}
@@ -94,7 +96,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
                                 className={clsx(
                                     "label",
                                     `label__status--${status}`,
-                                    Icon && `label__hasIcon`,
+                                    leftIcon && `label__hasIcon`,
                                 )}
                                 htmlFor={label.toString()}
                             >
@@ -113,14 +115,14 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
                         )}
                     </div>
 
-                    {StatusIcon && (
+                    {rightIcon && (
                         <span
                             className={clsx(
                                 "icon_wrapper",
                                 statusIconColors[status],
                             )}
                         >
-                            {StatusIcon}
+                            {rightIcon}
                         </span>
                     )}
                 </div>

--- a/lib/components/Input/base/index.tsx
+++ b/lib/components/Input/base/index.tsx
@@ -67,35 +67,38 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
                     )}
                 >
                     {Icon && <span className="icon_wrapper">{Icon}</span>}
-                    <input
-                        {...rest}
-                        type={type}
-                        className={clsx(
-                            "input",
-                            "peer",
-                            `input__align--${textAlignment}`,
-                            `input__size--${inputSize}`,
-                        )}
-                        disabled={!!disabled}
-                        onChange={(e) => {
-                            setHasValue(!!e.target.value);
-                            onChange?.(e);
-                        }}
-                        id={label?.toString()}
-                        ref={ref}
-                    />
-                    {label && inputSize === "md" && (
-                        <label
+                    <div className="quill-input-label__wrapper">
+                        <input
+                            {...rest}
+                            type={type}
                             className={clsx(
-                                "label",
-                                `label__status--${status}`,
-                                Icon && `label__hasIcon`,
+                                "input",
+                                "peer",
+                                `input__align--${textAlignment}`,
+                                `input__size--${inputSize}`,
                             )}
-                            htmlFor={label.toString()}
-                        >
-                            {label}
-                        </label>
-                    )}
+                            disabled={!!disabled}
+                            onChange={(e) => {
+                                setHasValue(!!e.target.value);
+                                onChange?.(e);
+                            }}
+                            id={label?.toString()}
+                            ref={ref}
+                        />
+                        {label && inputSize === "md" && (
+                            <label
+                                className={clsx(
+                                    "label",
+                                    `label__status--${status}`,
+                                    Icon && `label__hasIcon`,
+                                )}
+                                htmlFor={label.toString()}
+                            >
+                                {label}
+                            </label>
+                        )}
+                    </div>
+
                     {StatusIcon && (
                         <span
                             className={clsx(

--- a/lib/components/Input/base/index.tsx
+++ b/lib/components/Input/base/index.tsx
@@ -3,7 +3,7 @@ import { InputHTMLAttributes, ReactNode, forwardRef, useState } from "react";
 import "./base.scss";
 import React from "react";
 import { TMediumSizes } from "@types";
-import { CaptionText, Text } from "@components/Typography";
+import { CaptionText } from "@components/Typography";
 
 export type Variants = "fill" | "outline";
 export type Status = "neutral" | "success" | "error";

--- a/lib/components/Input/text-field/__tests__/__snapshots__/text-field.test.tsx.snap
+++ b/lib/components/Input/text-field/__tests__/__snapshots__/text-field.test.tsx.snap
@@ -8,10 +8,14 @@ exports[`TextField It should render a default Textfiled 1`] = `
     <div
       class="quill-input__wrapper quill-input__wrapper__variant--outline quill-input__wrapper__size--md quill-input__wrapper__status--neutral"
     >
-      <input
-        class="input peer input__align--left input__size--md"
-        type="text"
-      />
+      <div
+        class="quill-input-label__wrapper"
+      >
+        <input
+          class="input peer input__align--left input__size--md"
+          type="text"
+        />
+      </div>
     </div>
     <div
       class="message__container"
@@ -22,7 +26,7 @@ exports[`TextField It should render a default Textfiled 1`] = `
 
 exports[`TextField should handle the hover for outline variant 1`] = `
 <div
-  class="quill-input__wrapper quill-input__wrapper__variant--outline quill-input__wrapper__size--md quill-input__wrapper__status--neutral"
+  class="quill-input-label__wrapper"
 >
   <input
     class="input peer input__align--left input__size--md"
@@ -40,10 +44,14 @@ exports[`TextField should render a TextField with error status 1`] = `
     <div
       class="quill-input__wrapper quill-input__wrapper__variant--outline quill-input__wrapper__size--md quill-input__wrapper__status--error"
     >
-      <input
-        class="input peer input__align--left input__size--md"
-        type="text"
-      />
+      <div
+        class="quill-input-label__wrapper"
+      >
+        <input
+          class="input peer input__align--left input__size--md"
+          type="text"
+        />
+      </div>
     </div>
     <div
       class="message__container"
@@ -60,10 +68,14 @@ exports[`TextField should render a TextField with success status 1`] = `
     <div
       class="quill-input__wrapper quill-input__wrapper__variant--outline quill-input__wrapper__size--md quill-input__wrapper__status--success"
     >
-      <input
-        class="input peer input__align--left input__size--md"
-        type="text"
-      />
+      <div
+        class="quill-input-label__wrapper"
+      >
+        <input
+          class="input peer input__align--left input__size--md"
+          type="text"
+        />
+      </div>
     </div>
     <div
       class="message__container"

--- a/lib/components/Input/text-field/text-field.stories.tsx
+++ b/lib/components/Input/text-field/text-field.stories.tsx
@@ -3,9 +3,15 @@ import TextField from ".";
 import {
     StandaloneCircleCheckBoldIcon,
     StandaloneCircleUserRegularIcon,
+    StandalonePlaceholderRegularIcon,
     StandaloneTriangleExclamationBoldIcon,
 } from "@deriv/quill-icons";
 import { Status, Variants } from "../base";
+
+const icons: Record<string, object | null> = {
+    with_icon: <StandalonePlaceholderRegularIcon />,
+    none: null,
+};
 
 const placeholder = "Placeholder";
 
@@ -45,6 +51,13 @@ const meta = {
                 type: "radio",
             },
             options: ["sm", "md"],
+        },
+        icon: {
+            options: Object.keys(icons),
+            mapping: icons,
+            control: {
+                type: "select",
+            },
         },
         status: {
             control: {

--- a/lib/components/Input/text-field/text-field.stories.tsx
+++ b/lib/components/Input/text-field/text-field.stories.tsx
@@ -61,14 +61,14 @@ const meta = {
             },
             options: ["sm", "md"],
         },
-        icon: {
+        leftIcon: {
             options: Object.keys(icons),
             mapping: icons,
             control: {
                 type: "select",
             },
         },
-        statusIcon: {
+        rightIcon: {
             options: Object.keys(statusIcon),
             mapping: statusIcon,
             control: {
@@ -153,7 +153,7 @@ export const TextFieldWithIconAndLabel: Story = {
     args: {
         placeholder,
         label,
-        icon: <StandaloneCircleUserRegularIcon iconSize="sm" />,
+        leftIcon: <StandaloneCircleUserRegularIcon iconSize="sm" />,
     },
 };
 
@@ -162,7 +162,7 @@ export const SuccessStatusIconTextField: Story = {
         placeholder,
         variant: variants.outline,
         status: status.success,
-        statusIcon: <StandaloneCircleCheckBoldIcon iconSize="sm" />,
+        rightIcon: <StandaloneCircleCheckBoldIcon iconSize="sm" />,
     },
     argTypes: {
         status: {
@@ -199,7 +199,14 @@ export const SuccessMessageTextFieldWithIcons: Story = {
         status: status.success,
         leftStatusMessage,
         rightStatusMessage,
-        statusIcon: <StandaloneCircleCheckBoldIcon iconSize="sm" />,
+        rightIcon: <StandaloneCircleCheckBoldIcon iconSize="sm" />,
+    },
+    argTypes: {
+        rightIcon: {
+            table: {
+                disable: true,
+            },
+        },
     },
 };
 export const ErrorMessageTextFieldWithIcons: Story = {
@@ -209,6 +216,13 @@ export const ErrorMessageTextFieldWithIcons: Story = {
         status: status.error,
         leftStatusMessage,
         rightStatusMessage,
-        statusIcon: <StandaloneTriangleExclamationBoldIcon iconSize="sm" />,
+        rightIcon: <StandaloneTriangleExclamationBoldIcon iconSize="sm" />,
+    },
+    argTypes: {
+        rightIcon: {
+            table: {
+                disable: true,
+            },
+        },
     },
 };

--- a/lib/components/Input/text-field/text-field.stories.tsx
+++ b/lib/components/Input/text-field/text-field.stories.tsx
@@ -9,7 +9,14 @@ import {
 import { Status, Variants } from "../base";
 
 const icons: Record<string, object | null> = {
-    with_icon: <StandalonePlaceholderRegularIcon />,
+    with_icon: <StandalonePlaceholderRegularIcon iconSize="sm" />,
+    none: null,
+};
+
+const statusIcon: Record<string, object | null> = {
+    placeholder: <StandalonePlaceholderRegularIcon iconSize="sm" />,
+    success: <StandaloneCircleCheckBoldIcon iconSize="sm" />,
+    error: <StandaloneTriangleExclamationBoldIcon iconSize="sm" />,
     none: null,
 };
 
@@ -44,6 +51,8 @@ const meta = {
         disabled: false,
         variant: "fill",
         textAlignment: "left",
+        fieldMarker: false,
+        required: false,
     },
     argTypes: {
         inputSize: {
@@ -55,6 +64,13 @@ const meta = {
         icon: {
             options: Object.keys(icons),
             mapping: icons,
+            control: {
+                type: "select",
+            },
+        },
+        statusIcon: {
+            options: Object.keys(statusIcon),
+            mapping: statusIcon,
             control: {
                 type: "select",
             },


### PR DESCRIPTION
- update default text field has a white background
<img width="247" alt="image" src="https://github.com/deriv-com/quill-ui/assets/142988136/f4e415d8-fd23-4b92-a971-1108b0e68ef7">

- fix sm and md font size, now md is 16px and sm is 14px
- fix icon not center
<img width="247" alt="image" src="https://github.com/deriv-com/quill-ui/assets/142988136/ec52fed6-211e-4cba-be06-b257dd229a8d">

- add field marker
<img width="333" alt="Screenshot 2024-04-26 at 1 52 11 PM" src="https://github.com/deriv-com/quill-ui/assets/142988136/fe771fb6-a5e2-42dc-9dad-521d2b030477">

