### PR TITLE
Jia/_/action-sheet-subtask

### DIFF
--- a/lib/components/ActionSheet/button-trigger.stories.tsx
+++ b/lib/components/ActionSheet/button-trigger.stories.tsx
@@ -6,6 +6,11 @@ import {
     StandaloneXmarkRegularIcon,
 } from "@deriv/quill-icons";
 
+const icons: Record<string, object | null> = {
+    with_icon: <LabelPairedPlaceholderCaptionBoldIcon />,
+    none: null,
+};
+
 const meta: Meta = {
     title: "Components/Action Sheet/Button Trigger",
     component: ActionSheetExample,
@@ -15,7 +20,6 @@ const meta: Meta = {
         title: "Title",
         description: "Description",
         closeIcon: <StandaloneXmarkRegularIcon />,
-        icon: <LabelPairedPlaceholderCaptionBoldIcon />,
     },
     argTypes: {
         isOpen: { table: { disable: true } },
@@ -59,6 +63,11 @@ const meta: Meta = {
         icon: {
             description:
                 "This props allowed you to pass in icon for `ActionSheet.Header`",
+            options: Object.keys(icons),
+            mapping: icons,
+            control: {
+                type: "radio",
+            },
         },
         primaryAction: {
             control: {

--- a/lib/components/ActionSheet/content/content.scss
+++ b/lib/components/ActionSheet/content/content.scss
@@ -4,4 +4,5 @@
     padding-top: var(--semantic-spacing-general-lg);
     padding-bottom: var(--semantic-spacing-general-lg);
     flex-grow: 1;
+    overflow-y: auto;
 }

--- a/lib/components/ActionSheet/controlled.stories.tsx
+++ b/lib/components/ActionSheet/controlled.stories.tsx
@@ -7,6 +7,11 @@ import {
     StandaloneXmarkRegularIcon,
 } from "@deriv/quill-icons";
 
+const icons: Record<string, object | null> = {
+    with_icon: <LabelPairedPlaceholderCaptionBoldIcon />,
+    none: null,
+};
+
 const meta: Meta = {
     title: "Components/Action Sheet/Controlled",
     component: ActionSheetExampleControlled,
@@ -21,7 +26,6 @@ const meta: Meta = {
         description: "Description",
         type: "non-modal",
         closeIcon: <StandaloneXmarkRegularIcon />,
-        icon: <LabelPairedPlaceholderCaptionBoldIcon />,
         onOpen: fn(),
     },
     argTypes: {
@@ -56,6 +60,15 @@ const meta: Meta = {
             options: ["left", "right"],
             control: { type: "radio" },
             description: "This prop will make bottom sheet expandable",
+        },
+        icon: {
+            description:
+                "This props allowed you to pass in icon for `ActionSheet.Header`",
+            options: Object.keys(icons),
+            mapping: icons,
+            control: {
+                type: "radio",
+            },
         },
         primaryAction: {
             control: {

--- a/lib/components/ActionSheet/icon-trigger.stories.tsx
+++ b/lib/components/ActionSheet/icon-trigger.stories.tsx
@@ -7,6 +7,11 @@ import {
     StandaloneXmarkRegularIcon,
 } from "@deriv/quill-icons";
 
+const icons: Record<string, object | null> = {
+    with_icon: <LabelPairedPlaceholderCaptionBoldIcon />,
+    none: null,
+};
+
 const meta: Meta = {
     title: "Components/Action Sheet/Icon Trigger",
     component: ActionSheetExampleWithIconTrigger,
@@ -19,7 +24,6 @@ const meta: Meta = {
         title: "Title",
         description: "Description",
         closeIcon: <StandaloneXmarkRegularIcon />,
-        icon: <LabelPairedPlaceholderCaptionBoldIcon />,
         onOpen: fn(),
         isOpen: false,
     },
@@ -64,6 +68,15 @@ const meta: Meta = {
                 type: "object",
             },
             description: "Same as `primaryAction`",
+        },
+        icon: {
+            description:
+                "This props allowed you to pass in icon for `ActionSheet.Header`",
+            options: Object.keys(icons),
+            mapping: icons,
+            control: {
+                type: "radio",
+            },
         },
         alignment: {
             control: {

--- a/lib/components/ActionSheet/mocks/__tests__/__snapshots__/example.test.tsx.snap
+++ b/lib/components/ActionSheet/mocks/__tests__/__snapshots__/example.test.tsx.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Action sheet example Should render action sheet 1`] = `
+<div>
+  <button>
+    <button
+      class="quill-button quill-button__size--md quill__color--primary-coral"
+      data-state=""
+    >
+      <span
+        class="button-label"
+      >
+        <p
+          class="quill-typography__body-text__size--sm__weight--bold__decoration--default coral"
+        >
+          Click Here
+        </p>
+      </span>
+    </button>
+  </button>
+</div>
+`;

--- a/lib/components/ActionSheet/mocks/__tests__/__snapshots__/example.test.tsx.snap
+++ b/lib/components/ActionSheet/mocks/__tests__/__snapshots__/example.test.tsx.snap
@@ -20,3 +20,41 @@ exports[`Action sheet example Should render action sheet 1`] = `
   </button>
 </div>
 `;
+
+exports[`Action sheet example controlled Should render action sheet 1`] = `<div />`;
+
+exports[`Action sheet example with icon trigger Should render action sheet 1`] = `
+<div>
+  <button
+    class="quill-button quill-button__size--md quill__color--primary-coral"
+    data-state=""
+  >
+    <div>
+      <svg
+        class="mock-action-sheet--trigger"
+        data-testid="dt-actionsheet-icon-button"
+        height="22"
+        role="img"
+        viewBox="0 0 13 22"
+        width="13"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g>
+          <path
+            d="M.375 6.156c0-.355.273-.656.656-.656H11.97c.355 0 .656.3.656.656 0 .383-.3.657-.656.657H1.03a.63.63 0 0 1-.656-.657m0 4.375c0-.355.273-.656.656-.656H11.97c.355 0 .656.3.656.656 0 .383-.3.656-.656.656H1.03a.63.63 0 0 1-.656-.656m12.25 4.375c0 .383-.3.656-.656.656H1.03a.63.63 0 0 1-.656-.656c0-.355.273-.656.656-.656H11.97c.355 0 .656.3.656.656"
+          />
+        </g>
+        <defs>
+          <clippath
+            id="54f94bb3e1a15715c604fcf036ae35ad__a"
+          >
+            <path
+              d="M0 0h13v22H0z"
+            />
+          </clippath>
+        </defs>
+      </svg>
+    </div>
+  </button>
+</div>
+`;

--- a/lib/components/ActionSheet/mocks/__tests__/example.test.tsx
+++ b/lib/components/ActionSheet/mocks/__tests__/example.test.tsx
@@ -1,0 +1,9 @@
+import { render } from "@testing-library/react";
+import { ActionSheetExample } from "../example";
+
+describe("Action sheet example", () => {
+    it("Should render action sheet", () => {
+        const { container } = render(<ActionSheetExample />);
+        expect(container).toMatchSnapshot();
+    });
+});

--- a/lib/components/ActionSheet/mocks/__tests__/example.test.tsx
+++ b/lib/components/ActionSheet/mocks/__tests__/example.test.tsx
@@ -1,9 +1,27 @@
 import { render } from "@testing-library/react";
-import { ActionSheetExample } from "../example";
+import {
+    ActionSheetExample,
+    ActionSheetExampleWithIconTrigger,
+    ActionSheetExampleControlled,
+} from "../example";
 
 describe("Action sheet example", () => {
     it("Should render action sheet", () => {
         const { container } = render(<ActionSheetExample />);
+        expect(container).toMatchSnapshot();
+    });
+});
+
+describe("Action sheet example with icon trigger", () => {
+    it("Should render action sheet", () => {
+        const { container } = render(<ActionSheetExampleWithIconTrigger />);
+        expect(container).toMatchSnapshot();
+    });
+});
+
+describe("Action sheet example controlled", () => {
+    it("Should render action sheet", () => {
+        const { container } = render(<ActionSheetExampleControlled />);
         expect(container).toMatchSnapshot();
     });
 });

--- a/lib/components/ActionSheet/mocks/example.tsx
+++ b/lib/components/ActionSheet/mocks/example.tsx
@@ -107,6 +107,56 @@ export const ActionSheetExampleWithIconTrigger = ({
                             screen which includes content related to the
                             previous screen.
                         </Text>
+                        <Text size="sm">
+                            Bottom sheet is a surface fixed at the bottom of the
+                            screen which includes content related to the
+                            previous screen.
+                        </Text>
+                        <Text size="sm">
+                            Bottom sheet is a surface fixed at the bottom of the
+                            screen which includes content related to the
+                            previous screen.
+                        </Text>
+                        <Text size="sm">
+                            Bottom sheet is a surface fixed at the bottom of the
+                            screen which includes content related to the
+                            previous screen.
+                        </Text>
+                        <Text size="sm">
+                            Bottom sheet is a surface fixed at the bottom of the
+                            screen which includes content related to the
+                            previous screen.
+                        </Text>
+                        <Text size="sm">
+                            Bottom sheet is a surface fixed at the bottom of the
+                            screen which includes content related to the
+                            previous screen.
+                        </Text>
+                        <Text size="sm">
+                            Bottom sheet is a surface fixed at the bottom of the
+                            screen which includes content related to the
+                            previous screen.
+                        </Text>
+                        <Text size="sm">
+                            Bottom sheet is a surface fixed at the bottom of the
+                            screen which includes content related to the
+                            previous screen.
+                        </Text>
+                        <Text size="sm">
+                            Bottom sheet is a surface fixed at the bottom of the
+                            screen which includes content related to the
+                            previous screen.
+                        </Text>
+                        <Text size="sm">
+                            Bottom sheet is a surface fixed at the bottom of the
+                            screen which includes content related to the
+                            previous screen.
+                        </Text>
+                        <Text size="sm">
+                            Bottom sheet is a surface fixed at the bottom of the
+                            screen which includes content related to the
+                            previous screen.
+                        </Text>
                     </ActionSheet.Content>
                     <ActionSheet.Footer
                         primaryAction={primaryAction}


### PR DESCRIPTION
- update storybook to show and disable icon in the action sheet footer
<img width="506" alt="image" src="https://github.com/deriv-com/quill-ui/assets/142988136/fc9ef396-7569-4eb3-a0f0-9eb53bbd0e21">
<img width="401" alt="Screenshot 2024-04-23 at 8 54 50 PM" src="https://github.com/deriv-com/quill-ui/assets/142988136/f0de008e-290c-4c71-aacd-8743847a974e">

- fix action sheet scroll only for body content
<img width="401" alt="image" src="https://github.com/deriv-com/quill-ui/assets/142988136/9598d03c-3dff-4135-9a17-783d0cd327bb">

