### PR TITLE
Maryia/test: Add default timezone to jest config + Notifications improvements

### DIFF
--- a/globalSetup.js
+++ b/globalSetup.js
@@ -1,0 +1,4 @@
+export default async () => {
+    // eslint-disable-next-line no-undef
+    process.env.TZ = "UTC";
+};

--- a/lib/components/Notification/banners/banners.stories.tsx
+++ b/lib/components/Notification/banners/banners.stories.tsx
@@ -74,31 +74,25 @@ type Story = StoryObj<typeof meta>;
 
 const basicBanners = [
     {
-        id: "0",
         message: "This is an information message",
         redirectTo: "https://www.example.com",
         title: "Information",
         type: TYPE.INFO,
     },
     {
-        id: "1",
         message: "This is a warning message",
         redirectTo: "https://www.example.com",
         title: "Warning",
         type: TYPE.WARNING,
     },
     {
-        id: "2",
         message: "This is an error message",
         redirectTo: "https://www.example.com",
         title: "Error",
         type: TYPE.ERROR,
     },
 ];
-const initialBanners = [
-    ...basicBanners,
-    ...basicBanners.map((item) => ({ ...item, id: `${item.id}_unique` })),
-];
+const initialBanners = [...basicBanners, ...basicBanners];
 
 const Template: Story = {
     render: (args) => {

--- a/lib/components/Notification/item/__tests__/__snapshots__/item.test.tsx.snap
+++ b/lib/components/Notification/item/__tests__/__snapshots__/item.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`NotificationItem should display correct content 1`] = `
             aria-label="date-time"
             class="quill-typography__caption-text__weight--regular__decoration--default quill-typography__color--prominent date-time"
           >
-            23 Apr 2024 09:24 GMT+4
+            23 Apr 2024 09:24 UTC
           </p>
         </div>
       </div>
@@ -155,7 +155,7 @@ exports[`NotificationItem should display correct notification with a custom icon
             aria-label="date-time"
             class="quill-typography__caption-text__weight--regular__decoration--default quill-typography__color--prominent date-time"
           >
-            23 Apr 2024 09:24 GMT+4
+            23 Apr 2024 09:24 UTC
           </p>
         </div>
       </div>
@@ -270,7 +270,7 @@ exports[`NotificationItem should render correctly for mobile 1`] = `
             aria-label="date-time"
             class="quill-typography__caption-text__weight--regular__decoration--default quill-typography__color--prominent date-time"
           >
-            23 Apr 2024 09:24 GMT+4
+            23 Apr 2024 09:24 UTC
           </p>
         </div>
       </div>
@@ -385,7 +385,7 @@ exports[`NotificationItem should render notification correctly based on the noti
             aria-label="date-time"
             class="quill-typography__caption-text__weight--regular__decoration--default quill-typography__color--prominent date-time"
           >
-            23 Apr 2024 09:24 GMT+4
+            23 Apr 2024 09:24 UTC
           </p>
         </div>
       </div>
@@ -497,7 +497,7 @@ exports[`NotificationItem should render notification correctly when status is 'r
             aria-label="date-time"
             class="quill-typography__caption-text__weight--regular__decoration--default quill-typography__color--prominent date-time"
           >
-            23 Apr 2024 09:24 GMT+4
+            23 Apr 2024 09:24 UTC
           </p>
         </div>
       </div>

--- a/lib/components/Notification/item/index.tsx
+++ b/lib/components/Notification/item/index.tsx
@@ -15,8 +15,10 @@ export interface NotificationItemProps
         | "onSwipeUp"
     > {
     className?: string;
-    type?: (typeof TYPE)[keyof typeof TYPE];
     isMobile?: boolean;
+    onShowingButtons?: () => void;
+    showButtons: boolean;
+    type?: (typeof TYPE)[keyof typeof TYPE];
 }
 
 const DIRECTION = {
@@ -32,6 +34,8 @@ const NotificationItem = ({
     onClick,
     onClose,
     onMarkAsRead,
+    onShowingButtons,
+    showButtons,
     ...rest
 }: NotificationItemProps) => {
     const [isDeleted, setIsDeleted] = useState(false);
@@ -41,6 +45,10 @@ const NotificationItem = ({
     useEffect(() => {
         setIsRead(status === STATUS.READ);
     }, [status]);
+
+    useEffect(() => {
+        setShouldShowButtons(showButtons);
+    }, [showButtons]);
 
     const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
         handleMarkAsRead();
@@ -59,7 +67,9 @@ const NotificationItem = ({
     };
 
     const handleSwipe = (direction: string) => {
-        setShouldShowButtons(direction === DIRECTION.LEFT);
+        const isLeft = direction === DIRECTION.LEFT;
+        setShouldShowButtons(isLeft);
+        if (isLeft) onShowingButtons?.();
     };
 
     return (
@@ -77,8 +87,7 @@ const NotificationItem = ({
                         `show-buttons${isRead ? "--read" : ""}`,
                     className,
                 )}
-                // onBlur={() => setShouldShowButtons(false)}
-                onBlurCapture={() => setShouldShowButtons(false)}
+                onBlur={() => setShouldShowButtons(false)}
                 onClick={handleClick}
                 onClose={handleClose}
                 onMarkAsRead={handleMarkAsRead}

--- a/lib/components/Notification/item/index.tsx
+++ b/lib/components/Notification/item/index.tsx
@@ -77,7 +77,8 @@ const NotificationItem = ({
                         `show-buttons${isRead ? "--read" : ""}`,
                     className,
                 )}
-                onBlur={() => setShouldShowButtons(false)}
+                // @ts-expect-error using it instead of onBlur in order to make it work for iOS
+                onFocusOut={() => setShouldShowButtons(false)}
                 onClick={handleClick}
                 onClose={handleClose}
                 onMarkAsRead={handleMarkAsRead}

--- a/lib/components/Notification/item/index.tsx
+++ b/lib/components/Notification/item/index.tsx
@@ -83,7 +83,8 @@ const NotificationItem = ({
                 {...rest}
                 className={clsx(
                     `notification__item${isMobile ? "--mobile" : ""}`,
-                    shouldShowButtons &&
+                    isMobile &&
+                        shouldShowButtons &&
                         `show-buttons${isRead ? "--read" : ""}`,
                     className,
                 )}

--- a/lib/components/Notification/item/index.tsx
+++ b/lib/components/Notification/item/index.tsx
@@ -77,8 +77,8 @@ const NotificationItem = ({
                         `show-buttons${isRead ? "--read" : ""}`,
                     className,
                 )}
-                // @ts-expect-error using it instead of onBlur in order to make it work for iOS
-                onFocusOut={() => setShouldShowButtons(false)}
+                // onBlur={() => setShouldShowButtons(false)}
+                onBlurCapture={() => setShouldShowButtons(false)}
                 onClick={handleClick}
                 onClose={handleClose}
                 onMarkAsRead={handleMarkAsRead}

--- a/lib/components/Notification/item/index.tsx
+++ b/lib/components/Notification/item/index.tsx
@@ -17,7 +17,7 @@ export interface NotificationItemProps
     className?: string;
     isMobile?: boolean;
     onShowingButtons?: () => void;
-    showButtons: boolean;
+    showButtons?: boolean;
     type?: (typeof TYPE)[keyof typeof TYPE];
 }
 
@@ -47,7 +47,7 @@ const NotificationItem = ({
     }, [status]);
 
     useEffect(() => {
-        setShouldShowButtons(showButtons);
+        setShouldShowButtons(showButtons ?? false);
     }, [showButtons]);
 
     const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {

--- a/lib/components/Notification/items-list/__tests__/__snapshots__/items-list.test.tsx.snap
+++ b/lib/components/Notification/items-list/__tests__/__snapshots__/items-list.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`NotificationItemsList should render all notification items 1`] = `
               aria-label="date-time"
               class="quill-typography__caption-text__weight--regular__decoration--default quill-typography__color--prominent date-time"
             >
-              23 Apr 2024 09:24 GMT+4
+              23 Apr 2024 09:24 UTC
             </p>
           </div>
         </div>
@@ -155,7 +155,7 @@ exports[`NotificationItemsList should render all notification items 1`] = `
               aria-label="date-time"
               class="quill-typography__caption-text__weight--regular__decoration--default quill-typography__color--prominent date-time"
             >
-              23 Apr 2024 09:24 GMT+4
+              23 Apr 2024 09:24 UTC
             </p>
           </div>
         </div>
@@ -274,7 +274,7 @@ exports[`NotificationItemsList should render notifications correctly for mobile 
               aria-label="date-time"
               class="quill-typography__caption-text__weight--regular__decoration--default quill-typography__color--prominent date-time"
             >
-              23 Apr 2024 09:24 GMT+4
+              23 Apr 2024 09:24 UTC
             </p>
           </div>
         </div>
@@ -376,7 +376,7 @@ exports[`NotificationItemsList should render notifications correctly for mobile 
               aria-label="date-time"
               class="quill-typography__caption-text__weight--regular__decoration--default quill-typography__color--prominent date-time"
             >
-              23 Apr 2024 09:24 GMT+4
+              23 Apr 2024 09:24 UTC
             </p>
           </div>
         </div>

--- a/lib/components/Notification/items-list/index.tsx
+++ b/lib/components/Notification/items-list/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import clsx from "clsx";
 import NotificationItem from "../item";
 import type { NotificationItemProps } from "../item";
@@ -20,6 +20,7 @@ const NotificationItemsList = ({
     onClose,
     onMarkAsRead,
 }: NotificationItemsListProps) => {
+    const [activeItemId, setActiveItemId] = useState("");
     const timeoutIds = useRef<Array<ReturnType<typeof setTimeout>>>([]);
 
     useEffect(() => {
@@ -48,6 +49,10 @@ const NotificationItemsList = ({
                     onClick={() => onClick?.(id)}
                     onClose={() => handleClose?.(id)}
                     onMarkAsRead={() => onMarkAsRead?.(id)}
+                    onShowingButtons={
+                        isMobile ? () => setActiveItemId(id) : undefined
+                    }
+                    showButtons={!!isMobile && activeItemId === id}
                 />
             ))}
         </div>

--- a/lib/components/Notification/items-list/items-list.stories.tsx
+++ b/lib/components/Notification/items-list/items-list.stories.tsx
@@ -71,7 +71,6 @@ type Story = StoryObj<typeof meta>;
 
 const basicItems = [
     {
-        id: "0",
         message: "This is a very very long Information message",
         redirectTo: "https://www.example.com",
         status: STATUS.UNREAD,
@@ -80,7 +79,6 @@ const basicItems = [
         type: TYPE.INFO,
     },
     {
-        id: "1",
         message: "This is a very very very long Warning message",
         redirectTo: "https://www.example.com",
         status: STATUS.UNREAD,
@@ -89,7 +87,6 @@ const basicItems = [
         type: TYPE.WARNING,
     },
     {
-        id: "2",
         message: "This is a very very very long Error message",
         redirectTo: "https://www.example.com",
         status: STATUS.READ,
@@ -98,10 +95,7 @@ const basicItems = [
         type: TYPE.ERROR,
     },
 ];
-const initialNotifications = [
-    ...basicItems,
-    ...basicItems.map((item) => ({ ...item, id: `${item.id}_unique` })),
-];
+const initialNotifications = [...basicItems, ...basicItems];
 
 const Template: Story = {
     render: (args) => {

--- a/lib/hooks/useNotifications/__tests__/useNotifications.test.tsx
+++ b/lib/hooks/useNotifications/__tests__/useNotifications.test.tsx
@@ -125,4 +125,18 @@ describe("useNotifications", () => {
 
         expect(result.current.notificationItems).toHaveLength(0);
     });
+    it("should return banners with ids when receives initial banners without ids", () => {
+        const { result } = renderHook(
+            () => useNotifications({ banners: [{ title: "a" }] }),
+            { wrapper },
+        );
+        expect(result.current.banners[0].id).toBeDefined();
+    });
+    it("should return notification items with ids when receives initial notification items without ids", () => {
+        const { result } = renderHook(
+            () => useNotifications({ notificationItems: [{ title: "a" }] }),
+            { wrapper },
+        );
+        expect(result.current.notificationItems[0].id).toBeDefined();
+    });
 });

--- a/lib/hooks/useNotifications/index.ts
+++ b/lib/hooks/useNotifications/index.ts
@@ -4,8 +4,8 @@ import { NotificationBannerProps } from "@components/Notification";
 import { NotificationItemProps } from "@components/Notification/item";
 
 interface UseNotificationsParams {
-    banners?: Array<NotificationBannerProps & { id: string }>;
-    notificationItems?: Array<NotificationItemProps & { id: string }>;
+    banners?: Array<NotificationBannerProps & { id?: string }>;
+    notificationItems?: Array<NotificationItemProps & { id?: string }>;
 }
 
 export const useNotifications = (params?: UseNotificationsParams) => {

--- a/lib/providers/notification/notificationsContext.tsx
+++ b/lib/providers/notification/notificationsContext.tsx
@@ -15,10 +15,10 @@ export type NotificationsContextValue = {
     removeBanner: (id: string) => void;
     removeNotificationItem: (id: string) => void;
     updateBanners: (
-        banners: Array<NotificationBannerProps & { id: string }>,
+        banners: Array<NotificationBannerProps & { id?: string }>,
     ) => void;
     updateNotificationItems: (
-        notificationItems: Array<NotificationItemProps & { id: string }>,
+        notificationItems: Array<NotificationItemProps & { id?: string }>,
     ) => void;
 };
 

--- a/lib/providers/notification/notificationsProvider.tsx
+++ b/lib/providers/notification/notificationsProvider.tsx
@@ -1,4 +1,4 @@
-import { v4 as uuid } from 'uuid';
+import { v4 as uuid } from "uuid";
 import React, { useState, PropsWithChildren } from "react";
 import { NotificationsContext } from "./notificationsContext";
 import { NotificationBannerProps } from "@components/Notification/banner";
@@ -53,15 +53,19 @@ export const NotificationsProvider = ({ children }: PropsWithChildren) => {
     };
 
     const updateBanners = (
-        list: Array<NotificationBannerProps & { id: string }>,
+        list: Array<NotificationBannerProps & { id?: string }>,
     ) => {
-        setBanners([...list]);
+        setBanners(
+            list.map((banner) => ({ ...banner, id: banner.id || uuid() })),
+        );
     };
 
     const updateNotificationItems = (
-        list: Array<NotificationItemProps & { id: string }>,
+        list: Array<NotificationItemProps & { id?: string }>,
     ) => {
-        setNotificationItems([...list]);
+        setNotificationItems(
+            list.map((item) => ({ ...item, id: item.id || uuid() })),
+        );
     };
 
     return (

--- a/package.json
+++ b/package.json
@@ -125,7 +125,8 @@
             "^@hooks(.*)$": "<rootDir>/lib/hooks$1",
             "^@providers(.*)$": "<rootDir>/lib/providers$1",
             "^@utils(.*)$": "<rootDir>/lib/utils$1"
-        }
+        },
+        "globalSetup": "<rootDir>/globalSetup.js"
     },
     "dependencies": {
         "@deriv/quill-icons": "^1.19.20",


### PR DESCRIPTION
- Add default timezone to jest config 
- NotificationItem improvement for iOS to hide buttons upon clicking outside
- Add support for initial notification objects passed into useNotifications hook without ids: NotificationsProvider will add unique ids if they are missing.