### PR TITLE
DTRA-1162/ Kate / Fix: remove prevent default for focus

### DIFF
--- a/lib/components/SelectionControl/checkbox/checkbox-single/index.tsx
+++ b/lib/components/SelectionControl/checkbox/checkbox-single/index.tsx
@@ -89,7 +89,8 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
 
         const onKeyDown: React.KeyboardEventHandler<HTMLInputElement> = (e) => {
             e.stopPropagation();
-            if (e.key === KEY.ENTER) onChangeHandler(e);
+            if (e.key === KEY.SPACE) e.preventDefault();
+            if (e.key === KEY.ENTER || e.key === KEY.SPACE) onChangeHandler(e);
         };
 
         const determinateIcon = isChecked ? (

--- a/lib/components/SelectionControl/checkbox/checkbox-single/index.tsx
+++ b/lib/components/SelectionControl/checkbox/checkbox-single/index.tsx
@@ -89,8 +89,6 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
 
         const onKeyDown: React.KeyboardEventHandler<HTMLInputElement> = (e) => {
             e.stopPropagation();
-            e.preventDefault();
-
             if (e.key === KEY.ENTER || e.key === KEY.SPACE) onChangeHandler(e);
         };
 

--- a/lib/components/SelectionControl/checkbox/checkbox-single/index.tsx
+++ b/lib/components/SelectionControl/checkbox/checkbox-single/index.tsx
@@ -89,7 +89,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
 
         const onKeyDown: React.KeyboardEventHandler<HTMLInputElement> = (e) => {
             e.stopPropagation();
-            if (e.key === KEY.ENTER || e.key === KEY.SPACE) onChangeHandler(e);
+            if (e.key === KEY.ENTER) onChangeHandler(e);
         };
 
         const determinateIcon = isChecked ? (


### PR DESCRIPTION
- Removed `e.preventDefault();` from `keyDown` handler as it prevent `focus` from changing target.

https://github.com/deriv-com/quill-ui/assets/121025168/b990150b-1246-4604-b209-15092f617dce

