### PR TITLE
Meenu/[QUILL-786] Modal overlay component

### DIFF
--- a/lib/components/Modal/index.ts
+++ b/lib/components/Modal/index.ts
@@ -1,1 +1,2 @@
-export * from './bottom';
+export * from "./bottom";
+export * from "./overlay";

--- a/lib/components/Modal/overlay/__tests__/__snapshots__/modal-overlay.test.tsx.snap
+++ b/lib/components/Modal/overlay/__tests__/__snapshots__/modal-overlay.test.tsx.snap
@@ -1,0 +1,300 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ModalOverlay should render SVG if it was passed 1`] = `
+<div>
+  <div
+    class="quill-modal-overlay__background"
+    data-testid="dt_overlay"
+  >
+    <div
+      class="quill-modal-overlay__container quill-modal-overlay__container--visible"
+    >
+      <div
+        class="quill-modal-overlay__content-wrapper"
+      >
+        <svg
+          class="quill-modal-overlay__close-icon"
+          height="24"
+          role="img"
+          viewBox="0 0 12 24"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <g>
+            <path
+              d="m10.781 8.281-3.75 3.75 3.719 3.719a.684.684 0 0 1 0 1.031.684.684 0 0 1-1.031 0l-3.75-3.718L2.25 16.78a.684.684 0 0 1-1.031 0c-.313-.281-.313-.75 0-1.062L4.937 12 1.22 8.281c-.313-.281-.313-.75 0-1.062.281-.282.75-.282 1.062 0L6 10.969 9.719 7.25c.281-.312.75-.312 1.062 0a.736.736 0 0 1 0 1.031"
+            />
+          </g>
+          <defs>
+            <clippath
+              id="0eb845b2ab722910e8bf8487d5b230e3__a"
+            >
+              <path
+                d="M0 0h12v24H0z"
+              />
+            </clippath>
+          </defs>
+        </svg>
+        <div
+          class="quill-modal-overlay__content-image"
+        >
+          <svg
+            height="32"
+            role="img"
+            viewBox="0 0 32 32"
+            width="32"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M14.164 7.75a.61.61 0 0 0-.508.313L13.031 9h5.899l-.625-.937a.61.61 0 0 0-.508-.313zM20.375 9h3.75c.313 0 .625.313.625.625a.64.64 0 0 1-.625.625h-.742l-.977 13.945c-.117 1.328-1.172 2.305-2.5 2.305h-7.851a2.51 2.51 0 0 1-2.5-2.305L8.578 10.25h-.703a.617.617 0 0 1-.625-.625c0-.312.273-.625.625-.625h3.711l1.016-1.602a1.84 1.84 0 0 1 1.562-.898h3.633c.625 0 1.25.352 1.601.898zm1.758 1.25H9.828l.977 13.867c.039.625.586 1.133 1.25 1.133h7.851c.664 0 1.211-.508 1.25-1.133z"
+            />
+          </svg>
+        </div>
+        <h4
+          class="quill-typography__h4 quill-typography__color--prominent quill-modal-overlay__content-title"
+        >
+          Title
+        </h4>
+      </div>
+      <div
+        class="quill-modal-overlay__button-wrapper"
+      >
+        <button
+          class="quill-button quill-button__size--lg quill__color--primary-black quill-button__full-width"
+          data-state=""
+        >
+          <span
+            class="button-label"
+          >
+            <p
+              class="quill-typography__body-text__size--md__weight--bold__decoration--default black"
+            >
+              Primary Button Label
+            </p>
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ModalOverlay should render container with image as a background if src was passed 1`] = `
+<div>
+  <div
+    class="quill-modal-overlay__background"
+    data-testid="dt_overlay"
+  >
+    <div
+      class="quill-modal-overlay__container quill-modal-overlay__container--visible"
+    >
+      <div
+        class="quill-modal-overlay__content-wrapper"
+      >
+        <svg
+          class="quill-modal-overlay__close-icon"
+          height="24"
+          role="img"
+          viewBox="0 0 12 24"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <g>
+            <path
+              d="m10.781 8.281-3.75 3.75 3.719 3.719a.684.684 0 0 1 0 1.031.684.684 0 0 1-1.031 0l-3.75-3.718L2.25 16.78a.684.684 0 0 1-1.031 0c-.313-.281-.313-.75 0-1.062L4.937 12 1.22 8.281c-.313-.281-.313-.75 0-1.062.281-.282.75-.282 1.062 0L6 10.969 9.719 7.25c.281-.312.75-.312 1.062 0a.736.736 0 0 1 0 1.031"
+            />
+          </g>
+          <defs>
+            <clippath
+              id="0eb845b2ab722910e8bf8487d5b230e3__a"
+            >
+              <path
+                d="M0 0h12v24H0z"
+              />
+            </clippath>
+          </defs>
+        </svg>
+        <div
+          class="quill-modal-overlay__content-image"
+          data-testid="dt_modal_image"
+        />
+        <h4
+          class="quill-typography__h4 quill-typography__color--prominent quill-modal-overlay__content-title"
+        >
+          Title
+        </h4>
+      </div>
+      <div
+        class="quill-modal-overlay__button-wrapper"
+      >
+        <button
+          class="quill-button quill-button__size--lg quill__color--primary-black quill-button__full-width"
+          data-state=""
+        >
+          <span
+            class="button-label"
+          >
+            <p
+              class="quill-typography__body-text__size--md__weight--bold__decoration--default black"
+            >
+              Primary Button Label
+            </p>
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ModalOverlay should render secondary button if showSecondaryButton === true and the label was passed 1`] = `
+<div>
+  <div
+    class="quill-modal-overlay__background"
+    data-testid="dt_overlay"
+  >
+    <div
+      class="quill-modal-overlay__container quill-modal-overlay__container--visible"
+    >
+      <div
+        class="quill-modal-overlay__content-wrapper"
+      >
+        <svg
+          class="quill-modal-overlay__close-icon"
+          height="24"
+          role="img"
+          viewBox="0 0 12 24"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <g>
+            <path
+              d="m10.781 8.281-3.75 3.75 3.719 3.719a.684.684 0 0 1 0 1.031.684.684 0 0 1-1.031 0l-3.75-3.718L2.25 16.78a.684.684 0 0 1-1.031 0c-.313-.281-.313-.75 0-1.062L4.937 12 1.22 8.281c-.313-.281-.313-.75 0-1.062.281-.282.75-.282 1.062 0L6 10.969 9.719 7.25c.281-.312.75-.312 1.062 0a.736.736 0 0 1 0 1.031"
+            />
+          </g>
+          <defs>
+            <clippath
+              id="0eb845b2ab722910e8bf8487d5b230e3__a"
+            >
+              <path
+                d="M0 0h12v24H0z"
+              />
+            </clippath>
+          </defs>
+        </svg>
+        <h4
+          class="quill-typography__h4 quill-typography__color--prominent quill-modal-overlay__content-title"
+        >
+          Title
+        </h4>
+        <div
+          class="quill-typography__body-text__size--md__weight--regular__decoration--default quill-typography__color--default quill-modal-overlay__content-body"
+        >
+          This is some amazing placeholder.
+        </div>
+      </div>
+      <div
+        class="quill-modal-overlay__button-wrapper"
+      >
+        <button
+          class="quill-button quill-button__size--lg quill__color--primary-black quill-button__full-width"
+          data-state=""
+        >
+          <span
+            class="button-label"
+          >
+            <p
+              class="quill-typography__body-text__size--md__weight--bold__decoration--default black"
+            >
+              Primary Button Label
+            </p>
+          </span>
+        </button>
+        <button
+          class="quill-button quill-button__size--lg quill__color--secondary-black quill-modal-overlay__button quill-button__full-width"
+          data-state=""
+        >
+          <span
+            class="button-label"
+          >
+            <p
+              class="quill-typography__body-text__size--md__weight--bold__decoration--default black"
+            >
+              Secondary Button Label
+            </p>
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`ModalOverlay should render with default values if optional ones were not passed 1`] = `
+<div>
+  <div
+    class="quill-modal-overlay__background"
+    data-testid="dt_overlay"
+  >
+    <div
+      class="quill-modal-overlay__container quill-modal-overlay__container--visible"
+    >
+      <div
+        class="quill-modal-overlay__content-wrapper"
+      >
+        <svg
+          class="quill-modal-overlay__close-icon"
+          height="24"
+          role="img"
+          viewBox="0 0 12 24"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <g>
+            <path
+              d="m10.781 8.281-3.75 3.75 3.719 3.719a.684.684 0 0 1 0 1.031.684.684 0 0 1-1.031 0l-3.75-3.718L2.25 16.78a.684.684 0 0 1-1.031 0c-.313-.281-.313-.75 0-1.062L4.937 12 1.22 8.281c-.313-.281-.313-.75 0-1.062.281-.282.75-.282 1.062 0L6 10.969 9.719 7.25c.281-.312.75-.312 1.062 0a.736.736 0 0 1 0 1.031"
+            />
+          </g>
+          <defs>
+            <clippath
+              id="0eb845b2ab722910e8bf8487d5b230e3__a"
+            >
+              <path
+                d="M0 0h12v24H0z"
+              />
+            </clippath>
+          </defs>
+        </svg>
+        <h4
+          class="quill-typography__h4 quill-typography__color--prominent quill-modal-overlay__content-title"
+        >
+          Title
+        </h4>
+        <div
+          class="quill-typography__body-text__size--md__weight--regular__decoration--default quill-typography__color--default quill-modal-overlay__content-body"
+        >
+          This is some amazing placeholder.
+        </div>
+      </div>
+      <div
+        class="quill-modal-overlay__button-wrapper"
+      >
+        <button
+          class="quill-button quill-button__size--lg quill__color--primary-black quill-button__full-width"
+          data-state=""
+        >
+          <span
+            class="button-label"
+          >
+            <p
+              class="quill-typography__body-text__size--md__weight--bold__decoration--default black"
+            >
+              Primary Button Label
+            </p>
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/lib/components/Modal/overlay/__tests__/modal-overlay.test.tsx
+++ b/lib/components/Modal/overlay/__tests__/modal-overlay.test.tsx
@@ -1,0 +1,141 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { StandaloneTrashRegularIcon } from "@deriv/quill-icons";
+import { ModalOverlay } from "../index";
+
+describe("ModalOverlay", () => {
+    const primaryButtonLabel = "Primary Button Label";
+    const secondaryButtonLabel = "Secondary Button Label";
+    const shortTextContent = "This is some amazing placeholder.";
+    const title = "Title";
+    const imageSrc =
+        "https://live.staticflickr.com/603/21947667154_e63cc9252b_b.jpg";
+
+    const children = (
+        <>
+            <ModalOverlay.Header title={title} />
+            <ModalOverlay.Body>{shortTextContent}</ModalOverlay.Body>
+        </>
+    );
+
+    const mockProps = {
+        isOpened: true,
+        toggleModal: jest.fn(),
+        primaryButtonLabel,
+    };
+
+    beforeAll(() => {
+        (ReactDOM.createPortal as jest.Mock) = jest.fn(
+            (component) => component,
+        );
+    });
+
+    afterAll(() => {
+        (ReactDOM.createPortal as jest.Mock).mockClear();
+    });
+
+    it("should render with default values if optional ones were not passed", () => {
+        const { container } = render(
+            <ModalOverlay {...mockProps}>{children}</ModalOverlay>,
+        );
+
+        expect(container).toMatchSnapshot();
+    });
+
+    it("should call toggleModal if user clicks on the overlay", async () => {
+        render(<ModalOverlay {...mockProps}>{children}</ModalOverlay>);
+
+        userEvent.click(screen.getByTestId("dt_overlay"));
+        await waitFor(() => {
+            expect(mockProps.toggleModal).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    it("should render secondary button if showSecondaryButton === true and the label was passed", () => {
+        const { container } = render(
+            <ModalOverlay
+                {...mockProps}
+                showSecondaryButton
+                secondaryButtonLabel={secondaryButtonLabel}
+            >
+                {children}
+            </ModalOverlay>,
+        );
+
+        expect(screen.getByText(secondaryButtonLabel)).toBeInTheDocument();
+        expect(container).toMatchSnapshot();
+    });
+
+    it("should call toggleModal if user clicks on secondary button", async () => {
+        render(
+            <ModalOverlay
+                {...mockProps}
+                showSecondaryButton
+                secondaryButtonLabel={secondaryButtonLabel}
+            >
+                {children}
+            </ModalOverlay>,
+        );
+
+        userEvent.click(screen.getByText(secondaryButtonLabel));
+        await waitFor(() => {
+            expect(mockProps.toggleModal).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    it("should call toggleModal if user clicks on primary button and shouldCloseOnPrimaryButtonClick == true", async () => {
+        render(
+            <ModalOverlay {...mockProps} shouldCloseOnPrimaryButtonClick>
+                {children}
+            </ModalOverlay>,
+        );
+
+        userEvent.click(screen.getByText(primaryButtonLabel));
+        await waitFor(() => {
+            expect(mockProps.toggleModal).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    it("should call primaryButtonCallback if user clicks on primary button and primaryButtonCallback was passed", async () => {
+        const primaryButtonCallback = jest.fn();
+        render(
+            <ModalOverlay
+                {...mockProps}
+                primaryButtonCallback={primaryButtonCallback}
+            >
+                {children}
+            </ModalOverlay>,
+        );
+
+        userEvent.click(screen.getByText(primaryButtonLabel));
+        await waitFor(() => {
+            expect(primaryButtonCallback).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    it("should render container with image as a background if src was passed", () => {
+        const { container } = render(
+            <ModalOverlay {...mockProps}>
+                <ModalOverlay.Header src={imageSrc} title={title} />
+            </ModalOverlay>,
+        );
+
+        expect(screen.getByTestId("dt_modal_image")).toBeInTheDocument();
+        expect(container).toMatchSnapshot();
+    });
+
+    it("should render SVG if it was passed", () => {
+        const { container } = render(
+            <ModalOverlay {...mockProps}>
+                <ModalOverlay.Header
+                    title={title}
+                    image={<StandaloneTrashRegularIcon />}
+                />
+            </ModalOverlay>,
+        );
+
+        expect(container).toMatchSnapshot();
+    });
+});

--- a/lib/components/Modal/overlay/index.tsx
+++ b/lib/components/Modal/overlay/index.tsx
@@ -1,0 +1,115 @@
+import { useState, useEffect, HTMLAttributes } from "react";
+import clsx from "clsx";
+import "./modal-overlay.scss";
+import { ModalOverlayHeader } from "./modal-overlay-header";
+import { ModalOverlayBody } from "./modal-overlay-body";
+import { LabelPairedXmarkMdBoldIcon } from "@deriv/quill-icons/LabelPaired";
+import ReactDOM from "react-dom";
+import { Button } from "@components/Button";
+
+export interface ModalOverlayProps extends HTMLAttributes<HTMLDivElement> {
+    isOpened?: boolean;
+    className?: string;
+    toggleModal: (isOpened: boolean) => void;
+    portalId?: string;
+    primaryButtonCallback?: () => void;
+    primaryButtonLabel?: React.ReactNode;
+    secondaryButtonCallback?: () => void;
+    secondaryButtonLabel?: React.ReactNode;
+    shouldCloseOnPrimaryButtonClick?: boolean;
+    shouldCloseOnSecondaryButtonClick?: boolean;
+    showSecondaryButton?: boolean;
+}
+
+export const ModalOverlay = ({
+    isOpened = false,
+    className,
+    children,
+    toggleModal,
+    primaryButtonCallback,
+    primaryButtonLabel,
+    secondaryButtonCallback,
+    secondaryButtonLabel,
+    shouldCloseOnPrimaryButtonClick,
+    shouldCloseOnSecondaryButtonClick,
+    showSecondaryButton,
+    portalId,
+    ...rest
+}: React.PropsWithChildren<ModalOverlayProps>) => {
+    const [isVisible, setIsVisible] = useState(isOpened);
+
+    const modalRoot =
+        (portalId && document.getElementById(portalId)) ||
+        document.getElementById("modal-root") ||
+        document.body;
+
+    useEffect(() => {
+        setIsVisible(isOpened);
+    }, [isOpened]);
+
+    const toggleHandler = () => {
+        setIsVisible(!isVisible);
+        toggleModal(!isVisible);
+    };
+    const primaryButtonFunctionHandler = () => {
+        primaryButtonCallback?.();
+        if (shouldCloseOnPrimaryButtonClick) toggleHandler();
+    };
+    const secondaryButtonFunctionHandler = () => {
+        secondaryButtonCallback?.();
+        if (shouldCloseOnSecondaryButtonClick) toggleHandler();
+    };
+
+    if (!isOpened) return null;
+
+    return ReactDOM.createPortal(
+        <div
+            {...rest}
+            className="quill-modal-overlay__background"
+            data-testid="dt_overlay"
+            onClick={toggleHandler}
+        >
+            <div
+                className={clsx(
+                    "quill-modal-overlay__container",
+                    {
+                        "quill-modal-overlay__container--visible": isVisible,
+                    },
+                    className,
+                )}
+                onClick={(e) => e.stopPropagation()}
+            >
+                <div className="quill-modal-overlay__content-wrapper">
+                    <LabelPairedXmarkMdBoldIcon
+                        className="quill-modal-overlay__close-icon"
+                        onClick={toggleHandler}
+                    />
+                    {children}
+                </div>
+                <div className="quill-modal-overlay__button-wrapper">
+                    <Button
+                        color="black"
+                        fullWidth
+                        size="lg"
+                        label={primaryButtonLabel}
+                        onClick={primaryButtonFunctionHandler}
+                    />
+                    {showSecondaryButton && (
+                        <Button
+                            color="black"
+                            fullWidth
+                            size="lg"
+                            label={secondaryButtonLabel}
+                            variant="secondary"
+                            className="quill-modal-overlay__button"
+                            onClick={secondaryButtonFunctionHandler}
+                        />
+                    )}
+                </div>
+            </div>
+        </div>,
+        modalRoot,
+    );
+};
+ModalOverlay.Header = ModalOverlayHeader;
+ModalOverlay.Body = ModalOverlayBody;

--- a/lib/components/Modal/overlay/modal-overlay-body.tsx
+++ b/lib/components/Modal/overlay/modal-overlay-body.tsx
@@ -1,0 +1,19 @@
+import clsx from "clsx";
+import { Text } from "@components/Typography";
+
+export interface ModalOverlayBodyProps {
+    className?: string;
+}
+
+export const ModalOverlayBody = ({
+    children,
+    className,
+}: React.PropsWithChildren<ModalOverlayBodyProps>) => (
+    <Text
+        size="md"
+        as="div"
+        className={clsx("quill-modal-overlay__content-body", className)}
+    >
+        {children}
+    </Text>
+);

--- a/lib/components/Modal/overlay/modal-overlay-header.tsx
+++ b/lib/components/Modal/overlay/modal-overlay-header.tsx
@@ -1,0 +1,60 @@
+import clsx from "clsx";
+import { Heading } from "@components/Typography";
+
+export interface ModalOverlayHeaderProps {
+    className?: string;
+    height?: string;
+    image?: React.ReactNode;
+    src?: string;
+    style?: React.CSSProperties;
+    title?: React.ReactNode | undefined;
+}
+
+export const ModalOverlayHeader = ({
+    className,
+    height = "var(--temp-static-spacing-202)",
+    image,
+    src,
+    style,
+    title,
+}: ModalOverlayHeaderProps) => {
+    return (
+        <>
+            {src && (
+                <div
+                    style={{
+                        background: `url(${src}) lightgray 50% / cover no-repeat`,
+                        height: `${height}`,
+                        ...style,
+                    }}
+                    className={clsx(
+                        "quill-modal-overlay__content-image",
+                        className,
+                    )}
+                    data-testid="dt_modal_image"
+                />
+            )}
+            {image && (
+                <div
+                    style={style}
+                    className={clsx(
+                        "quill-modal-overlay__content-image",
+                        className,
+                    )}
+                >
+                    {image}
+                </div>
+            )}
+            {title && (
+                <Heading.H4
+                    className={clsx(
+                        "quill-modal-overlay__content-title",
+                        className,
+                    )}
+                >
+                    {title}
+                </Heading.H4>
+            )}
+        </>
+    );
+};

--- a/lib/components/Modal/overlay/modal-overlay.scss
+++ b/lib/components/Modal/overlay/modal-overlay.scss
@@ -1,0 +1,78 @@
+.quill-modal-overlay {
+    &__background {
+        position: fixed;
+        left: 0;
+        right: 0;
+        top: 0;
+        bottom: 0;
+        z-index: 9999;
+        display: flex;
+        align-items: center;
+        background-color: var(--core-color-opacity-black-600);
+    }
+    &__container {
+        position: relative;
+        overflow: hidden;
+        display: flex;
+        border-radius: var(--core-borderRadius-1600);
+        width: 512px;
+        justify-content: space-evenly;
+        flex-direction: column;
+        background-color: var(--component-modal-bg);
+        margin : 0 auto;
+        transition: all var(--core-motion-duration-300)
+            var(--motion-easing-linear);
+
+        &--visible {
+            opacity: var(--core-opacity-1300);
+            transform: translateY(0%);
+            pointer-events: auto;
+        }
+    }
+    &__close-icon {
+        position: absolute;
+        cursor: pointer;
+        top: var(--core-spacing-1600);
+        right: var(--core-spacing-1600);
+    }
+    &__content {
+        &-wrapper {
+            flex-grow: 1;
+            overflow-y: scroll;
+        }
+
+        &-image {
+            min-height: var(--temp-static-spacing-144);
+            display: flex;
+            justify-content: center;
+            align-items: center;
+
+            & + .quill-modal-overlay__content-title {
+               padding-top: var(--core-spacing-1200);
+            }
+        }
+
+        &-title {
+            padding: var(--core-spacing-1600);
+           
+        }
+
+        &-body {
+           padding-inline: var(--core-spacing-1600) ;
+           padding-bottom: var(--core-spacing-1200);
+        }
+    }
+    &__button {
+        border-width: var(--core-borderWidth-75);
+
+        &-wrapper {
+            align-self: stretch;
+            padding: var(--core-spacing-1200) var(--core-spacing-1600);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            flex-direction: column;
+            gap: var(--semantic-spacing-gap-md);
+        }
+    }
+}

--- a/lib/components/Modal/overlay/modal-overlay.stories.tsx
+++ b/lib/components/Modal/overlay/modal-overlay.stories.tsx
@@ -1,0 +1,208 @@
+import type { Meta } from "@storybook/react";
+import { ModalOverlay } from "./index";
+import { useEffect, useState } from "react";
+import { Button } from "@components/Button";
+import { fn } from "@storybook/test";
+import {
+    StandaloneCircleSterlingRegularIcon,
+    StandaloneTrashRegularIcon,
+} from "@deriv/quill-icons/Standalone";
+
+interface Template extends React.ComponentProps<typeof ModalOverlay> {
+    image?: React.ReactNode;
+    src?: string;
+    style?: React.CSSProperties;
+    textContent?: React.ReactNode;
+}
+
+const openModalButtonLabel = "Open Modal";
+const primaryButtonLabel = "Primary Button Label";
+const secondaryButtonLabel = "Secondary Button Label";
+const shortTextContent = "This is some amazing placeholder.";
+const placeHolderText =
+    "Lorem ipsum dolor sit amet consectetur. Venenatis malesuada nibh sed ornare rnare id suspendisse sed.";
+const mediumTextContent = placeHolderText.padStart(200, placeHolderText);
+const longTextContent = placeHolderText.padStart(600, placeHolderText);
+const titlePlaceHolderText = "Title";
+const imageSRC =
+    "https://live.staticflickr.com/603/21947667154_e63cc9252b_b.jpg";
+const ImageComponent = <img src={imageSRC} alt="Apples" />;
+
+const preloadImage = (imageSRC: string) => {
+    const img = new Image();
+    img.src = imageSRC;
+};
+
+preloadImage(imageSRC);
+const meta = {
+    title: "Components/Modal/Overlay",
+    component: ModalOverlay,
+    tags: ["autodocs"],
+
+    args: {
+        children: <div>{shortTextContent}</div>,
+        isOpened: false,
+        showSecondaryButton: true,
+        shouldCloseOnPrimaryButtonClick: false,
+        toggleModal: fn(),
+        primaryButtonLabel: primaryButtonLabel,
+        primaryButtonCallback: fn(),
+        secondaryButtonLabel: secondaryButtonLabel,
+    },
+    argTypes: {
+        children: {
+            table: { type: { summary: "ReactNode" } },
+            description:
+                "Modal's content. Can be wrapped with the `<ModalOverlay.Header/>` and `<ModalOverlay.Body/>` components in order to organize the content inside the modal. Each of them accepts className for customization and `<ModalOverlay.Header/>` can also be passed scr and height properties.",
+            control: { type: null },
+        },
+        isOpened: {
+            table: { type: { summary: "boolean | undefined" } },
+            options: ["true", "false"],
+            description: "Controls the visibility of the modal",
+            control: { type: "boolean" },
+        },
+        className: {
+            table: { type: { summary: "string | undefined" } },
+            description: "ClassName for external tag of the component.",
+            control: { type: "text" },
+        },
+        showSecondaryButton: {
+            table: { type: { summary: "boolean | undefined" } },
+            options: ["true", "false"],
+            description: "Controls the visibility of the secondary button.",
+            control: { type: "boolean" },
+        },
+        shouldCloseOnPrimaryButtonClick: {
+            table: { type: { summary: "boolean | undefined" } },
+            options: ["true", "false"],
+            description:
+                "Flag for controlling modal behavior. If it's true, then the modal will be closed after user clicks on the primary button.",
+            control: { type: "boolean" },
+        },
+        toggleModal: {
+            table: { type: { summary: "(isOpened: boolean) => void" } },
+            description:
+                "Function for changing state of the visibility of the modal.",
+            control: { type: null },
+        },
+        portalId: {
+            table: { type: { summary: "string | undefined" } },
+            description:
+                "ID of the modal container. If it wasn't passed, the modal will try to find any container with 'modal-root' ID. If there is no container with 'modal-root' ID the modal will be insert inside document.body.",
+            control: { type: "string" },
+        },
+        primaryButtonLabel: {
+            table: { type: { summary: "ReactNode" } },
+            description: "Label for the primary button.",
+            control: { type: "string" },
+        },
+        primaryButtonCallback: {
+            table: { type: { summary: "(() => void) | undefined" } },
+            description:
+                "Function which will be called on clicking on primary button.",
+            control: { type: null },
+        },
+        secondaryButtonLabel: {
+            table: { type: { summary: "ReactNode | undefined" } },
+            description: "Label for the secondary button.",
+            control: { type: "string" },
+        },
+    },
+} satisfies Meta<typeof ModalOverlay>;
+
+export default meta;
+
+const Template: React.FC<Template> = ({
+    image,
+    src,
+    style,
+    textContent = shortTextContent,
+    ...args
+}: Template) => {
+    const [isOpen, setIsOpen] = useState(args.isOpened);
+
+    useEffect(() => {
+        setIsOpen(args.isOpened);
+    }, [args.isOpened]);
+
+    return (
+        <>
+            <Button
+                size="lg"
+                label={openModalButtonLabel}
+                onClick={() => setIsOpen(true)}
+            />
+
+            <ModalOverlay {...args} isOpened={isOpen} toggleModal={setIsOpen}>
+                <ModalOverlay.Header
+                    title={titlePlaceHolderText}
+                    image={image}
+                    src={src}
+                    style={style}
+                />
+                <ModalOverlay.Body>{textContent}</ModalOverlay.Body>
+            </ModalOverlay>
+        </>
+    );
+};
+export const DefaultModalOverlay = Template.bind(this, meta.args);
+
+export const ModalOverlayWithImage = Template.bind(this, {
+    ...meta.args,
+    image: ImageComponent,
+});
+export const ModalOverlayWithoutSecondaryButton = Template.bind(this, {
+    ...meta.args,
+    showSecondaryButton: false,
+});
+
+export const ClosingModalOverlayOnPrimaryButtonClick = Template.bind(this, {
+    ...meta.args,
+    shouldCloseOnPrimaryButtonClick: true,
+    textContent: mediumTextContent,
+});
+
+export const ModalOverlayExpandedByDefault = Template.bind(this, {
+    ...meta.args,
+    textContent: longTextContent,
+});
+
+export const ModalOverlayWithImageAndLongContent = Template.bind(this, {
+    ...meta.args,
+    image: ImageComponent,
+    textContent: longTextContent,
+});
+
+export const ModalOverlayWithImageSrc = Template.bind(this, {
+    ...meta.args,
+    src: imageSRC,
+    textContent: mediumTextContent,
+});
+
+export const ModalOverlayWithIcon = Template.bind(this, {
+    ...meta.args,
+    image: (
+        <StandaloneTrashRegularIcon
+            fill="var(--core-color-solid-red-900)"
+            iconSize="2xl"
+        />
+    ),
+    style: {
+        backgroundColor: "var(--core-color-solid-red-100)",
+    },
+});
+
+export const ModalOverlayWithIconAndLongContent = Template.bind(this, {
+    ...meta.args,
+    image: (
+        <StandaloneCircleSterlingRegularIcon
+            fill="var(--core-color-solid-green-900)"
+            iconSize="2xl"
+        />
+    ),
+    style: {
+        backgroundColor: "var(--core-color-solid-green-100)",
+    },
+    textContent: longTextContent,
+});


### PR DESCRIPTION
Modal overlay (desktop only)

This component is used only for desktop and it accepts props for button, image, icon or any content. Implementation is similar to modal button except the position of the container. The main container is fixed to the center of the page. 


![Screenshot 2024-05-03 at 4 05 14 PM](https://github.com/deriv-com/quill-ui/assets/104189801/d0d2228b-84a9-48ce-8192-0415106187fe)
![Screenshot 2024-05-03 at 4 05 33 PM](https://github.com/deriv-com/quill-ui/assets/104189801/714157f6-0d22-4b1f-996a-a5005ab9a8a1)
