### PR TITLE
Prince/ Temporarily adding jsx-runtime as part of bundle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22386,12 +22386,6 @@
                 "react": "^16.8.3 || ^17 || ^18"
             }
         },
-        "node_modules/react-uuid": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/react-uuid/-/react-uuid-2.0.0.tgz",
-            "integrity": "sha512-FNUH/8WR/FEtx0Bu6gmt1eONfc413hhvrEXFWUSFGvznUhI4dYoVZA09p7JHoTpnM4WC2D/bG2YSxGKXF4oVLg==",
-            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info."
-        },
         "node_modules/read-pkg": {
             "version": "9.0.1",
             "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -48,7 +48,7 @@ export default defineConfig({
         copyPublicDir: false,
         cssCodeSplit: false,
         rollupOptions: {
-            external: ["react", "react/jsx-runtime", "react-dom"],
+            external: ["react", "react-dom"],
             input: Object.fromEntries(
                 glob
                     .sync("lib/**/*.{ts,tsx}", {


### PR DESCRIPTION
We are currently addressing an issue where consumers are unable to build the library due to version mismatches. To temporarily resolve this, we'll host the library containing the issue, ensuring that our consumers can continue development unimpeded. Please note that this temporary solution may slightly increase our bundle size by approximately `100-200kb`.

