### PR TITLE
DTRA-1192 / Kate/ DatePicker component

### DIFF
--- a/lib/components/Atom/Calendar/__tests__/__snapshots__/date-picker.test.tsx.snap
+++ b/lib/components/Atom/Calendar/__tests__/__snapshots__/date-picker.test.tsx.snap
@@ -1,0 +1,3191 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DatePicker should render calendar with double navigation if next2Label and prev2Label were passed 1`] = `
+<div>
+  <div
+    class="quill-date-picker__wrapper quill-date-picker__wrapper--fixed-width"
+  >
+    <div
+      class="react-calendar quill-date-picker"
+    >
+      <div
+        class="react-calendar__navigation"
+      >
+        <button
+          aria-label=""
+          class="react-calendar__navigation__arrow react-calendar__navigation__prev2-button"
+          type="button"
+        >
+          -
+        </button>
+        <button
+          aria-label=""
+          class="react-calendar__navigation__arrow react-calendar__navigation__prev-button"
+          type="button"
+        >
+          <svg
+            fill="var(--component-textIcon-normal-prominent)"
+            height="22"
+            role="img"
+            viewBox="0 0 9 22"
+            width="9"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g>
+              <path
+                d="m.371 10.148 5.25-5.25a.843.843 0 0 1 1.23 0 .843.843 0 0 1 0 1.23l-4.62 4.622 4.62 4.648a.843.843 0 0 1 0 1.23.843.843 0 0 1-1.23 0l-5.25-5.25a.843.843 0 0 1 0-1.23"
+              />
+            </g>
+            <defs>
+              <clippath
+                id="6049a3c1b96fe3c190d81d503231b188__a"
+              >
+                <path
+                  d="M0 0h9v22H0z"
+                />
+              </clippath>
+            </defs>
+          </svg>
+        </button>
+        <button
+          aria-label=""
+          class="react-calendar__navigation__label"
+          style="flex-grow: 1;"
+          type="button"
+        >
+          <span
+            class="react-calendar__navigation__label__labelText react-calendar__navigation__label__labelText--from"
+          >
+            <span
+              class="quill-typography__body-text__size--md__weight--regular__decoration--default quill-typography__color--default"
+            >
+              May 2024
+            </span>
+          </span>
+        </button>
+        <button
+          aria-label=""
+          class="react-calendar__navigation__arrow react-calendar__navigation__next-button"
+          type="button"
+        >
+          <svg
+            fill="var(--component-textIcon-normal-prominent)"
+            height="22"
+            role="img"
+            viewBox="0 0 9 22"
+            width="9"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g>
+              <path
+                d="M8.602 10.148a.843.843 0 0 1 0 1.23l-5.25 5.25a.843.843 0 0 1-1.23 0 .843.843 0 0 1 0-1.23l4.62-4.648-4.62-4.621a.843.843 0 0 1 0-1.23.843.843 0 0 1 1.23 0z"
+              />
+            </g>
+            <defs>
+              <clippath
+                id="c1516145807584bd1deec9aa0497255a__a"
+              >
+                <path
+                  d="M0 0h9v22H0z"
+                />
+              </clippath>
+            </defs>
+          </svg>
+        </button>
+        <button
+          aria-label=""
+          class="react-calendar__navigation__arrow react-calendar__navigation__next2-button"
+          type="button"
+        >
+          +
+        </button>
+      </div>
+      <div
+        class="react-calendar__viewContainer"
+      >
+        <div
+          class="react-calendar__month-view"
+        >
+          <div
+            style="display: flex; align-items: flex-end;"
+          >
+            <div
+              style="flex-grow: 1; width: 100%;"
+            >
+              <div
+                class="react-calendar__month-view__weekdays"
+                style="display: flex; flex-wrap: nowrap;"
+              >
+                <div
+                  class="react-calendar__month-view__weekdays__weekday"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Monday"
+                    title="Monday"
+                  >
+                    Mon
+                  </abbr>
+                </div>
+                <div
+                  class="react-calendar__month-view__weekdays__weekday"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Tuesday"
+                    title="Tuesday"
+                  >
+                    Tue
+                  </abbr>
+                </div>
+                <div
+                  class="react-calendar__month-view__weekdays__weekday"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Wednesday"
+                    title="Wednesday"
+                  >
+                    Wed
+                  </abbr>
+                </div>
+                <div
+                  class="react-calendar__month-view__weekdays__weekday"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Thursday"
+                    title="Thursday"
+                  >
+                    Thu
+                  </abbr>
+                </div>
+                <div
+                  class="react-calendar__month-view__weekdays__weekday react-calendar__month-view__weekdays__weekday--current"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Friday"
+                    title="Friday"
+                  >
+                    Fri
+                  </abbr>
+                </div>
+                <div
+                  class="react-calendar__month-view__weekdays__weekday react-calendar__month-view__weekdays__weekday--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Saturday"
+                    title="Saturday"
+                  >
+                    Sat
+                  </abbr>
+                </div>
+                <div
+                  class="react-calendar__month-view__weekdays__weekday react-calendar__month-view__weekdays__weekday--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Sunday"
+                    title="Sunday"
+                  >
+                    Sun
+                  </abbr>
+                </div>
+              </div>
+              <div
+                class="react-calendar__month-view__days"
+                style="display: flex; flex-wrap: wrap;"
+              >
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-left: 28.571428571428573%; margin-inline-start: 28.571428571428573%; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 1, 2024"
+                  >
+                    1
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 2, 2024"
+                  >
+                    2
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 3, 2024"
+                  >
+                    3
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 4, 2024"
+                  >
+                    4
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 5, 2024"
+                  >
+                    5
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 6, 2024"
+                  >
+                    6
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 7, 2024"
+                  >
+                    7
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 8, 2024"
+                  >
+                    8
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 9, 2024"
+                  >
+                    9
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__tile--now react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 10, 2024"
+                  >
+                    10
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 11, 2024"
+                  >
+                    11
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 12, 2024"
+                  >
+                    12
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 13, 2024"
+                  >
+                    13
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 14, 2024"
+                  >
+                    14
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 15, 2024"
+                  >
+                    15
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 16, 2024"
+                  >
+                    16
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 17, 2024"
+                  >
+                    17
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 18, 2024"
+                  >
+                    18
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 19, 2024"
+                  >
+                    19
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 20, 2024"
+                  >
+                    20
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 21, 2024"
+                  >
+                    21
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 22, 2024"
+                  >
+                    22
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 23, 2024"
+                  >
+                    23
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 24, 2024"
+                  >
+                    24
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 25, 2024"
+                  >
+                    25
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 26, 2024"
+                  >
+                    26
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 27, 2024"
+                  >
+                    27
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 28, 2024"
+                  >
+                    28
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 29, 2024"
+                  >
+                    29
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 30, 2024"
+                  >
+                    30
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 31, 2024"
+                  >
+                    31
+                  </abbr>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DatePicker should render calendar with neighboring month if showNeighboringMonth === true 1`] = `
+<div>
+  <div
+    class="quill-date-picker__wrapper quill-date-picker__wrapper--fixed-width"
+  >
+    <div
+      class="react-calendar quill-date-picker"
+    >
+      <div
+        class="react-calendar__navigation"
+      >
+        <button
+          aria-label=""
+          class="react-calendar__navigation__arrow react-calendar__navigation__prev-button"
+          type="button"
+        >
+          <svg
+            fill="var(--component-textIcon-normal-prominent)"
+            height="22"
+            role="img"
+            viewBox="0 0 9 22"
+            width="9"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g>
+              <path
+                d="m.371 10.148 5.25-5.25a.843.843 0 0 1 1.23 0 .843.843 0 0 1 0 1.23l-4.62 4.622 4.62 4.648a.843.843 0 0 1 0 1.23.843.843 0 0 1-1.23 0l-5.25-5.25a.843.843 0 0 1 0-1.23"
+              />
+            </g>
+            <defs>
+              <clippath
+                id="6049a3c1b96fe3c190d81d503231b188__a"
+              >
+                <path
+                  d="M0 0h9v22H0z"
+                />
+              </clippath>
+            </defs>
+          </svg>
+        </button>
+        <button
+          aria-label=""
+          class="react-calendar__navigation__label"
+          style="flex-grow: 1;"
+          type="button"
+        >
+          <span
+            class="react-calendar__navigation__label__labelText react-calendar__navigation__label__labelText--from"
+          >
+            <span
+              class="quill-typography__body-text__size--md__weight--regular__decoration--default quill-typography__color--default"
+            >
+              May 2024
+            </span>
+          </span>
+        </button>
+        <button
+          aria-label=""
+          class="react-calendar__navigation__arrow react-calendar__navigation__next-button"
+          type="button"
+        >
+          <svg
+            fill="var(--component-textIcon-normal-prominent)"
+            height="22"
+            role="img"
+            viewBox="0 0 9 22"
+            width="9"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g>
+              <path
+                d="M8.602 10.148a.843.843 0 0 1 0 1.23l-5.25 5.25a.843.843 0 0 1-1.23 0 .843.843 0 0 1 0-1.23l4.62-4.648-4.62-4.621a.843.843 0 0 1 0-1.23.843.843 0 0 1 1.23 0z"
+              />
+            </g>
+            <defs>
+              <clippath
+                id="c1516145807584bd1deec9aa0497255a__a"
+              >
+                <path
+                  d="M0 0h9v22H0z"
+                />
+              </clippath>
+            </defs>
+          </svg>
+        </button>
+      </div>
+      <div
+        class="react-calendar__viewContainer"
+      >
+        <div
+          class="react-calendar__month-view"
+        >
+          <div
+            style="display: flex; align-items: flex-end;"
+          >
+            <div
+              style="flex-grow: 1; width: 100%;"
+            >
+              <div
+                class="react-calendar__month-view__weekdays"
+                style="display: flex; flex-wrap: nowrap;"
+              >
+                <div
+                  class="react-calendar__month-view__weekdays__weekday"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Monday"
+                    title="Monday"
+                  >
+                    Mon
+                  </abbr>
+                </div>
+                <div
+                  class="react-calendar__month-view__weekdays__weekday"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Tuesday"
+                    title="Tuesday"
+                  >
+                    Tue
+                  </abbr>
+                </div>
+                <div
+                  class="react-calendar__month-view__weekdays__weekday"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Wednesday"
+                    title="Wednesday"
+                  >
+                    Wed
+                  </abbr>
+                </div>
+                <div
+                  class="react-calendar__month-view__weekdays__weekday"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Thursday"
+                    title="Thursday"
+                  >
+                    Thu
+                  </abbr>
+                </div>
+                <div
+                  class="react-calendar__month-view__weekdays__weekday react-calendar__month-view__weekdays__weekday--current"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Friday"
+                    title="Friday"
+                  >
+                    Fri
+                  </abbr>
+                </div>
+                <div
+                  class="react-calendar__month-view__weekdays__weekday react-calendar__month-view__weekdays__weekday--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Saturday"
+                    title="Saturday"
+                  >
+                    Sat
+                  </abbr>
+                </div>
+                <div
+                  class="react-calendar__month-view__weekdays__weekday react-calendar__month-view__weekdays__weekday--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Sunday"
+                    title="Sunday"
+                  >
+                    Sun
+                  </abbr>
+                </div>
+              </div>
+              <div
+                class="react-calendar__month-view__days"
+                style="display: flex; flex-wrap: wrap;"
+              >
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--neighboringMonth"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="April 29, 2024"
+                  >
+                    29
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--neighboringMonth"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="April 30, 2024"
+                  >
+                    30
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 1, 2024"
+                  >
+                    1
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 2, 2024"
+                  >
+                    2
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 3, 2024"
+                  >
+                    3
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 4, 2024"
+                  >
+                    4
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 5, 2024"
+                  >
+                    5
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 6, 2024"
+                  >
+                    6
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 7, 2024"
+                  >
+                    7
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 8, 2024"
+                  >
+                    8
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 9, 2024"
+                  >
+                    9
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__tile--now react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 10, 2024"
+                  >
+                    10
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 11, 2024"
+                  >
+                    11
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 12, 2024"
+                  >
+                    12
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 13, 2024"
+                  >
+                    13
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 14, 2024"
+                  >
+                    14
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 15, 2024"
+                  >
+                    15
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 16, 2024"
+                  >
+                    16
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 17, 2024"
+                  >
+                    17
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 18, 2024"
+                  >
+                    18
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 19, 2024"
+                  >
+                    19
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 20, 2024"
+                  >
+                    20
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 21, 2024"
+                  >
+                    21
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 22, 2024"
+                  >
+                    22
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 23, 2024"
+                  >
+                    23
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 24, 2024"
+                  >
+                    24
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 25, 2024"
+                  >
+                    25
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 26, 2024"
+                  >
+                    26
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 27, 2024"
+                  >
+                    27
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 28, 2024"
+                  >
+                    28
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 29, 2024"
+                  >
+                    29
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 30, 2024"
+                  >
+                    30
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 31, 2024"
+                  >
+                    31
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend react-calendar__month-view__days__day--neighboringMonth"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="June 1, 2024"
+                  >
+                    1
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend react-calendar__month-view__days__day--neighboringMonth"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="June 2, 2024"
+                  >
+                    2
+                  </abbr>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DatePicker should render calendar with range selection 1`] = `
+<div>
+  <div
+    class="quill-date-picker__wrapper quill-date-picker__wrapper--fixed-width"
+  >
+    <div
+      class="react-calendar react-calendar--selectRange quill-date-picker"
+    >
+      <div
+        class="react-calendar__navigation"
+      >
+        <button
+          aria-label=""
+          class="react-calendar__navigation__arrow react-calendar__navigation__prev-button"
+          type="button"
+        >
+          <svg
+            fill="var(--component-textIcon-normal-prominent)"
+            height="22"
+            role="img"
+            viewBox="0 0 9 22"
+            width="9"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g>
+              <path
+                d="m.371 10.148 5.25-5.25a.843.843 0 0 1 1.23 0 .843.843 0 0 1 0 1.23l-4.62 4.622 4.62 4.648a.843.843 0 0 1 0 1.23.843.843 0 0 1-1.23 0l-5.25-5.25a.843.843 0 0 1 0-1.23"
+              />
+            </g>
+            <defs>
+              <clippath
+                id="6049a3c1b96fe3c190d81d503231b188__a"
+              >
+                <path
+                  d="M0 0h9v22H0z"
+                />
+              </clippath>
+            </defs>
+          </svg>
+        </button>
+        <button
+          aria-label=""
+          class="react-calendar__navigation__label"
+          style="flex-grow: 1;"
+          type="button"
+        >
+          <span
+            class="react-calendar__navigation__label__labelText react-calendar__navigation__label__labelText--from"
+          >
+            <span
+              class="quill-typography__body-text__size--md__weight--regular__decoration--default quill-typography__color--default"
+            >
+              May 2024
+            </span>
+          </span>
+        </button>
+        <button
+          aria-label=""
+          class="react-calendar__navigation__arrow react-calendar__navigation__next-button"
+          type="button"
+        >
+          <svg
+            fill="var(--component-textIcon-normal-prominent)"
+            height="22"
+            role="img"
+            viewBox="0 0 9 22"
+            width="9"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g>
+              <path
+                d="M8.602 10.148a.843.843 0 0 1 0 1.23l-5.25 5.25a.843.843 0 0 1-1.23 0 .843.843 0 0 1 0-1.23l4.62-4.648-4.62-4.621a.843.843 0 0 1 0-1.23.843.843 0 0 1 1.23 0z"
+              />
+            </g>
+            <defs>
+              <clippath
+                id="c1516145807584bd1deec9aa0497255a__a"
+              >
+                <path
+                  d="M0 0h9v22H0z"
+                />
+              </clippath>
+            </defs>
+          </svg>
+        </button>
+      </div>
+      <div
+        class="react-calendar__viewContainer"
+      >
+        <div
+          class="react-calendar__month-view"
+        >
+          <div
+            style="display: flex; align-items: flex-end;"
+          >
+            <div
+              style="flex-grow: 1; width: 100%;"
+            >
+              <div
+                class="react-calendar__month-view__weekdays"
+                style="display: flex; flex-wrap: nowrap;"
+              >
+                <div
+                  class="react-calendar__month-view__weekdays__weekday"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Monday"
+                    title="Monday"
+                  >
+                    Mon
+                  </abbr>
+                </div>
+                <div
+                  class="react-calendar__month-view__weekdays__weekday"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Tuesday"
+                    title="Tuesday"
+                  >
+                    Tue
+                  </abbr>
+                </div>
+                <div
+                  class="react-calendar__month-view__weekdays__weekday"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Wednesday"
+                    title="Wednesday"
+                  >
+                    Wed
+                  </abbr>
+                </div>
+                <div
+                  class="react-calendar__month-view__weekdays__weekday"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Thursday"
+                    title="Thursday"
+                  >
+                    Thu
+                  </abbr>
+                </div>
+                <div
+                  class="react-calendar__month-view__weekdays__weekday react-calendar__month-view__weekdays__weekday--current"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Friday"
+                    title="Friday"
+                  >
+                    Fri
+                  </abbr>
+                </div>
+                <div
+                  class="react-calendar__month-view__weekdays__weekday react-calendar__month-view__weekdays__weekday--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Saturday"
+                    title="Saturday"
+                  >
+                    Sat
+                  </abbr>
+                </div>
+                <div
+                  class="react-calendar__month-view__weekdays__weekday react-calendar__month-view__weekdays__weekday--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Sunday"
+                    title="Sunday"
+                  >
+                    Sun
+                  </abbr>
+                </div>
+              </div>
+              <div
+                class="react-calendar__month-view__days"
+                style="display: flex; flex-wrap: wrap;"
+              >
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-left: 28.571428571428573%; margin-inline-start: 28.571428571428573%; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 1, 2024"
+                  >
+                    1
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 2, 2024"
+                  >
+                    2
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 3, 2024"
+                  >
+                    3
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 4, 2024"
+                  >
+                    4
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 5, 2024"
+                  >
+                    5
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 6, 2024"
+                  >
+                    6
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 7, 2024"
+                  >
+                    7
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 8, 2024"
+                  >
+                    8
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 9, 2024"
+                  >
+                    9
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__tile--now react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 10, 2024"
+                  >
+                    10
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 11, 2024"
+                  >
+                    11
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 12, 2024"
+                  >
+                    12
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 13, 2024"
+                  >
+                    13
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 14, 2024"
+                  >
+                    14
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 15, 2024"
+                  >
+                    15
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 16, 2024"
+                  >
+                    16
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 17, 2024"
+                  >
+                    17
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 18, 2024"
+                  >
+                    18
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 19, 2024"
+                  >
+                    19
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 20, 2024"
+                  >
+                    20
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 21, 2024"
+                  >
+                    21
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 22, 2024"
+                  >
+                    22
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 23, 2024"
+                  >
+                    23
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 24, 2024"
+                  >
+                    24
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 25, 2024"
+                  >
+                    25
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 26, 2024"
+                  >
+                    26
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 27, 2024"
+                  >
+                    27
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 28, 2024"
+                  >
+                    28
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 29, 2024"
+                  >
+                    29
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 30, 2024"
+                  >
+                    30
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 31, 2024"
+                  >
+                    31
+                  </abbr>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DatePicker should render calendar with selected value and call onFormattedDate function if value was passed 1`] = `
+<div>
+  <div
+    class="quill-date-picker__wrapper quill-date-picker__wrapper--fixed-width"
+  >
+    <div
+      class="react-calendar quill-date-picker"
+    >
+      <div
+        class="react-calendar__navigation"
+      >
+        <button
+          aria-label=""
+          class="react-calendar__navigation__arrow react-calendar__navigation__prev-button"
+          type="button"
+        >
+          <svg
+            fill="var(--component-textIcon-normal-prominent)"
+            height="22"
+            role="img"
+            viewBox="0 0 9 22"
+            width="9"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g>
+              <path
+                d="m.371 10.148 5.25-5.25a.843.843 0 0 1 1.23 0 .843.843 0 0 1 0 1.23l-4.62 4.622 4.62 4.648a.843.843 0 0 1 0 1.23.843.843 0 0 1-1.23 0l-5.25-5.25a.843.843 0 0 1 0-1.23"
+              />
+            </g>
+            <defs>
+              <clippath
+                id="6049a3c1b96fe3c190d81d503231b188__a"
+              >
+                <path
+                  d="M0 0h9v22H0z"
+                />
+              </clippath>
+            </defs>
+          </svg>
+        </button>
+        <button
+          aria-label=""
+          class="react-calendar__navigation__label"
+          style="flex-grow: 1;"
+          type="button"
+        >
+          <span
+            class="react-calendar__navigation__label__labelText react-calendar__navigation__label__labelText--from"
+          >
+            <span
+              class="quill-typography__body-text__size--md__weight--regular__decoration--default quill-typography__color--default"
+            >
+              May 2024
+            </span>
+          </span>
+        </button>
+        <button
+          aria-label=""
+          class="react-calendar__navigation__arrow react-calendar__navigation__next-button"
+          type="button"
+        >
+          <svg
+            fill="var(--component-textIcon-normal-prominent)"
+            height="22"
+            role="img"
+            viewBox="0 0 9 22"
+            width="9"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g>
+              <path
+                d="M8.602 10.148a.843.843 0 0 1 0 1.23l-5.25 5.25a.843.843 0 0 1-1.23 0 .843.843 0 0 1 0-1.23l4.62-4.648-4.62-4.621a.843.843 0 0 1 0-1.23.843.843 0 0 1 1.23 0z"
+              />
+            </g>
+            <defs>
+              <clippath
+                id="c1516145807584bd1deec9aa0497255a__a"
+              >
+                <path
+                  d="M0 0h9v22H0z"
+                />
+              </clippath>
+            </defs>
+          </svg>
+        </button>
+      </div>
+      <div
+        class="react-calendar__viewContainer"
+      >
+        <div
+          class="react-calendar__month-view"
+        >
+          <div
+            style="display: flex; align-items: flex-end;"
+          >
+            <div
+              style="flex-grow: 1; width: 100%;"
+            >
+              <div
+                class="react-calendar__month-view__weekdays"
+                style="display: flex; flex-wrap: nowrap;"
+              >
+                <div
+                  class="react-calendar__month-view__weekdays__weekday"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Monday"
+                    title="Monday"
+                  >
+                    Mon
+                  </abbr>
+                </div>
+                <div
+                  class="react-calendar__month-view__weekdays__weekday"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Tuesday"
+                    title="Tuesday"
+                  >
+                    Tue
+                  </abbr>
+                </div>
+                <div
+                  class="react-calendar__month-view__weekdays__weekday"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Wednesday"
+                    title="Wednesday"
+                  >
+                    Wed
+                  </abbr>
+                </div>
+                <div
+                  class="react-calendar__month-view__weekdays__weekday"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Thursday"
+                    title="Thursday"
+                  >
+                    Thu
+                  </abbr>
+                </div>
+                <div
+                  class="react-calendar__month-view__weekdays__weekday react-calendar__month-view__weekdays__weekday--current"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Friday"
+                    title="Friday"
+                  >
+                    Fri
+                  </abbr>
+                </div>
+                <div
+                  class="react-calendar__month-view__weekdays__weekday react-calendar__month-view__weekdays__weekday--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Saturday"
+                    title="Saturday"
+                  >
+                    Sat
+                  </abbr>
+                </div>
+                <div
+                  class="react-calendar__month-view__weekdays__weekday react-calendar__month-view__weekdays__weekday--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Sunday"
+                    title="Sunday"
+                  >
+                    Sun
+                  </abbr>
+                </div>
+              </div>
+              <div
+                class="react-calendar__month-view__days"
+                style="display: flex; flex-wrap: wrap;"
+              >
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-left: 28.571428571428573%; margin-inline-start: 28.571428571428573%; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 1, 2024"
+                  >
+                    1
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 2, 2024"
+                  >
+                    2
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 3, 2024"
+                  >
+                    3
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 4, 2024"
+                  >
+                    4
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 5, 2024"
+                  >
+                    5
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 6, 2024"
+                  >
+                    6
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 7, 2024"
+                  >
+                    7
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 8, 2024"
+                  >
+                    8
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 9, 2024"
+                  >
+                    9
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__tile--now react-calendar__tile--active react-calendar__tile--range react-calendar__tile--rangeStart react-calendar__tile--rangeEnd react-calendar__tile--rangeBothEnds react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 10, 2024"
+                  >
+                    10
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 11, 2024"
+                  >
+                    11
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 12, 2024"
+                  >
+                    12
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 13, 2024"
+                  >
+                    13
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 14, 2024"
+                  >
+                    14
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 15, 2024"
+                  >
+                    15
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 16, 2024"
+                  >
+                    16
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 17, 2024"
+                  >
+                    17
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 18, 2024"
+                  >
+                    18
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 19, 2024"
+                  >
+                    19
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 20, 2024"
+                  >
+                    20
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 21, 2024"
+                  >
+                    21
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 22, 2024"
+                  >
+                    22
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 23, 2024"
+                  >
+                    23
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 24, 2024"
+                  >
+                    24
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 25, 2024"
+                  >
+                    25
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 26, 2024"
+                  >
+                    26
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 27, 2024"
+                  >
+                    27
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 28, 2024"
+                  >
+                    28
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 29, 2024"
+                  >
+                    29
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 30, 2024"
+                  >
+                    30
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 31, 2024"
+                  >
+                    31
+                  </abbr>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DatePicker should render calendar without navigation if showNavigation === false 1`] = `
+<div>
+  <div
+    class="quill-date-picker__wrapper quill-date-picker__wrapper--fixed-width"
+  >
+    <div
+      class="react-calendar quill-date-picker"
+    >
+      <div
+        class="react-calendar__viewContainer"
+      >
+        <div
+          class="react-calendar__month-view"
+        >
+          <div
+            style="display: flex; align-items: flex-end;"
+          >
+            <div
+              style="flex-grow: 1; width: 100%;"
+            >
+              <div
+                class="react-calendar__month-view__weekdays"
+                style="display: flex; flex-wrap: nowrap;"
+              >
+                <div
+                  class="react-calendar__month-view__weekdays__weekday"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Monday"
+                    title="Monday"
+                  >
+                    Mon
+                  </abbr>
+                </div>
+                <div
+                  class="react-calendar__month-view__weekdays__weekday"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Tuesday"
+                    title="Tuesday"
+                  >
+                    Tue
+                  </abbr>
+                </div>
+                <div
+                  class="react-calendar__month-view__weekdays__weekday"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Wednesday"
+                    title="Wednesday"
+                  >
+                    Wed
+                  </abbr>
+                </div>
+                <div
+                  class="react-calendar__month-view__weekdays__weekday"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Thursday"
+                    title="Thursday"
+                  >
+                    Thu
+                  </abbr>
+                </div>
+                <div
+                  class="react-calendar__month-view__weekdays__weekday react-calendar__month-view__weekdays__weekday--current"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Friday"
+                    title="Friday"
+                  >
+                    Fri
+                  </abbr>
+                </div>
+                <div
+                  class="react-calendar__month-view__weekdays__weekday react-calendar__month-view__weekdays__weekday--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Saturday"
+                    title="Saturday"
+                  >
+                    Sat
+                  </abbr>
+                </div>
+                <div
+                  class="react-calendar__month-view__weekdays__weekday react-calendar__month-view__weekdays__weekday--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Sunday"
+                    title="Sunday"
+                  >
+                    Sun
+                  </abbr>
+                </div>
+              </div>
+              <div
+                class="react-calendar__month-view__days"
+                style="display: flex; flex-wrap: wrap;"
+              >
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-left: 28.571428571428573%; margin-inline-start: 28.571428571428573%; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 1, 2024"
+                  >
+                    1
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 2, 2024"
+                  >
+                    2
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 3, 2024"
+                  >
+                    3
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 4, 2024"
+                  >
+                    4
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 5, 2024"
+                  >
+                    5
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 6, 2024"
+                  >
+                    6
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 7, 2024"
+                  >
+                    7
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 8, 2024"
+                  >
+                    8
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 9, 2024"
+                  >
+                    9
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__tile--now react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 10, 2024"
+                  >
+                    10
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 11, 2024"
+                  >
+                    11
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 12, 2024"
+                  >
+                    12
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 13, 2024"
+                  >
+                    13
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 14, 2024"
+                  >
+                    14
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 15, 2024"
+                  >
+                    15
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 16, 2024"
+                  >
+                    16
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 17, 2024"
+                  >
+                    17
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 18, 2024"
+                  >
+                    18
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 19, 2024"
+                  >
+                    19
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 20, 2024"
+                  >
+                    20
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 21, 2024"
+                  >
+                    21
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 22, 2024"
+                  >
+                    22
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 23, 2024"
+                  >
+                    23
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 24, 2024"
+                  >
+                    24
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 25, 2024"
+                  >
+                    25
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 26, 2024"
+                  >
+                    26
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 27, 2024"
+                  >
+                    27
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 28, 2024"
+                  >
+                    28
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 29, 2024"
+                  >
+                    29
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 30, 2024"
+                  >
+                    30
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 31, 2024"
+                  >
+                    31
+                  </abbr>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DatePicker should render with default values if optional ones were not passed 1`] = `
+<div>
+  <div
+    class="quill-date-picker__wrapper quill-date-picker__wrapper--fixed-width"
+  >
+    <div
+      class="react-calendar quill-date-picker"
+    >
+      <div
+        class="react-calendar__navigation"
+      >
+        <button
+          aria-label=""
+          class="react-calendar__navigation__arrow react-calendar__navigation__prev-button"
+          type="button"
+        >
+          <svg
+            fill="var(--component-textIcon-normal-prominent)"
+            height="22"
+            role="img"
+            viewBox="0 0 9 22"
+            width="9"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g>
+              <path
+                d="m.371 10.148 5.25-5.25a.843.843 0 0 1 1.23 0 .843.843 0 0 1 0 1.23l-4.62 4.622 4.62 4.648a.843.843 0 0 1 0 1.23.843.843 0 0 1-1.23 0l-5.25-5.25a.843.843 0 0 1 0-1.23"
+              />
+            </g>
+            <defs>
+              <clippath
+                id="6049a3c1b96fe3c190d81d503231b188__a"
+              >
+                <path
+                  d="M0 0h9v22H0z"
+                />
+              </clippath>
+            </defs>
+          </svg>
+        </button>
+        <button
+          aria-label=""
+          class="react-calendar__navigation__label"
+          style="flex-grow: 1;"
+          type="button"
+        >
+          <span
+            class="react-calendar__navigation__label__labelText react-calendar__navigation__label__labelText--from"
+          >
+            <span
+              class="quill-typography__body-text__size--md__weight--regular__decoration--default quill-typography__color--default"
+            >
+              May 2024
+            </span>
+          </span>
+        </button>
+        <button
+          aria-label=""
+          class="react-calendar__navigation__arrow react-calendar__navigation__next-button"
+          type="button"
+        >
+          <svg
+            fill="var(--component-textIcon-normal-prominent)"
+            height="22"
+            role="img"
+            viewBox="0 0 9 22"
+            width="9"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g>
+              <path
+                d="M8.602 10.148a.843.843 0 0 1 0 1.23l-5.25 5.25a.843.843 0 0 1-1.23 0 .843.843 0 0 1 0-1.23l4.62-4.648-4.62-4.621a.843.843 0 0 1 0-1.23.843.843 0 0 1 1.23 0z"
+              />
+            </g>
+            <defs>
+              <clippath
+                id="c1516145807584bd1deec9aa0497255a__a"
+              >
+                <path
+                  d="M0 0h9v22H0z"
+                />
+              </clippath>
+            </defs>
+          </svg>
+        </button>
+      </div>
+      <div
+        class="react-calendar__viewContainer"
+      >
+        <div
+          class="react-calendar__month-view"
+        >
+          <div
+            style="display: flex; align-items: flex-end;"
+          >
+            <div
+              style="flex-grow: 1; width: 100%;"
+            >
+              <div
+                class="react-calendar__month-view__weekdays"
+                style="display: flex; flex-wrap: nowrap;"
+              >
+                <div
+                  class="react-calendar__month-view__weekdays__weekday"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Monday"
+                    title="Monday"
+                  >
+                    Mon
+                  </abbr>
+                </div>
+                <div
+                  class="react-calendar__month-view__weekdays__weekday"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Tuesday"
+                    title="Tuesday"
+                  >
+                    Tue
+                  </abbr>
+                </div>
+                <div
+                  class="react-calendar__month-view__weekdays__weekday"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Wednesday"
+                    title="Wednesday"
+                  >
+                    Wed
+                  </abbr>
+                </div>
+                <div
+                  class="react-calendar__month-view__weekdays__weekday"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Thursday"
+                    title="Thursday"
+                  >
+                    Thu
+                  </abbr>
+                </div>
+                <div
+                  class="react-calendar__month-view__weekdays__weekday react-calendar__month-view__weekdays__weekday--current"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Friday"
+                    title="Friday"
+                  >
+                    Fri
+                  </abbr>
+                </div>
+                <div
+                  class="react-calendar__month-view__weekdays__weekday react-calendar__month-view__weekdays__weekday--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Saturday"
+                    title="Saturday"
+                  >
+                    Sat
+                  </abbr>
+                </div>
+                <div
+                  class="react-calendar__month-view__weekdays__weekday react-calendar__month-view__weekdays__weekday--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                >
+                  <abbr
+                    aria-label="Sunday"
+                    title="Sunday"
+                  >
+                    Sun
+                  </abbr>
+                </div>
+              </div>
+              <div
+                class="react-calendar__month-view__days"
+                style="display: flex; flex-wrap: wrap;"
+              >
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-left: 28.571428571428573%; margin-inline-start: 28.571428571428573%; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 1, 2024"
+                  >
+                    1
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 2, 2024"
+                  >
+                    2
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 3, 2024"
+                  >
+                    3
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 4, 2024"
+                  >
+                    4
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 5, 2024"
+                  >
+                    5
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 6, 2024"
+                  >
+                    6
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 7, 2024"
+                  >
+                    7
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 8, 2024"
+                  >
+                    8
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 9, 2024"
+                  >
+                    9
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__tile--now react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 10, 2024"
+                  >
+                    10
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 11, 2024"
+                  >
+                    11
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 12, 2024"
+                  >
+                    12
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 13, 2024"
+                  >
+                    13
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 14, 2024"
+                  >
+                    14
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 15, 2024"
+                  >
+                    15
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 16, 2024"
+                  >
+                    16
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 17, 2024"
+                  >
+                    17
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 18, 2024"
+                  >
+                    18
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 19, 2024"
+                  >
+                    19
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 20, 2024"
+                  >
+                    20
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 21, 2024"
+                  >
+                    21
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 22, 2024"
+                  >
+                    22
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 23, 2024"
+                  >
+                    23
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 24, 2024"
+                  >
+                    24
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 25, 2024"
+                  >
+                    25
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 26, 2024"
+                  >
+                    26
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 27, 2024"
+                  >
+                    27
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 28, 2024"
+                  >
+                    28
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 29, 2024"
+                  >
+                    29
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 30, 2024"
+                  >
+                    30
+                  </abbr>
+                </button>
+                <button
+                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
+                  type="button"
+                >
+                  <abbr
+                    aria-label="May 31, 2024"
+                  >
+                    31
+                  </abbr>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/lib/components/Atom/Calendar/__tests__/date-picker.test.tsx
+++ b/lib/components/Atom/Calendar/__tests__/date-picker.test.tsx
@@ -1,0 +1,127 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { DatePicker } from "../index";
+
+describe("DatePicker", () => {
+    const currentDate = new Date();
+    const defaultDateFormatter = currentDate.toLocaleString(
+        navigator.languages,
+        {
+            month: "short",
+            year: "numeric",
+        },
+    );
+    const defaultReturnedSelectedDateFormatter = currentDate.toLocaleString(
+        navigator.language,
+        {
+            day: "2-digit",
+            month: "2-digit",
+            year: "numeric",
+        },
+    );
+    const customOptionsConfig = {
+        day: "numeric",
+        month: "short",
+        year: "numeric",
+    };
+    const customReturnedSelectedDateFormatter = currentDate.toLocaleString(
+        navigator.language,
+        customOptionsConfig as Intl.DateTimeFormatOptions,
+    );
+    const next2Label = "+";
+    const prev2Label = "-";
+    const mockOnFormattedDate = jest.fn();
+    const mockOnChange = jest.fn();
+
+    it("should render with default values if optional ones were not passed", () => {
+        const { container } = render(<DatePicker />);
+
+        expect(container).toMatchSnapshot();
+        ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"].forEach((day) =>
+            expect(screen.getByText(day)).toBeInTheDocument(),
+        );
+        expect(screen.getByText(defaultDateFormatter)).toBeInTheDocument();
+        expect(mockOnFormattedDate).not.toHaveBeenCalled();
+    });
+
+    it("should call onChange and onFormattedDate if they were passed and user clicks on the date", async () => {
+        render(
+            <DatePicker
+                onChange={mockOnChange}
+                onFormattedDate={mockOnFormattedDate}
+            />,
+        );
+
+        userEvent.click(screen.getByText(currentDate.getDate()));
+
+        await waitFor(() => {
+            expect(mockOnChange).toHaveBeenCalled();
+            expect(mockOnFormattedDate).toHaveBeenCalledWith(
+                defaultReturnedSelectedDateFormatter,
+            );
+        });
+    });
+
+    it("should format returned selected date according to the passed custom config", async () => {
+        render(
+            <DatePicker
+                onFormattedDate={mockOnFormattedDate}
+                optionsConfig={customOptionsConfig}
+            />,
+        );
+
+        userEvent.click(screen.getByText(currentDate.getDate()));
+
+        await waitFor(() => {
+            expect(mockOnFormattedDate).toHaveBeenCalledWith(
+                customReturnedSelectedDateFormatter,
+            );
+        });
+    });
+
+    it("should render calendar with selected value and call onFormattedDate function if the value was passed", () => {
+        const { container } = render(
+            <DatePicker
+                value={currentDate}
+                onFormattedDate={mockOnFormattedDate}
+            />,
+        );
+
+        expect(container).toMatchSnapshot();
+        expect(mockOnFormattedDate).toHaveBeenCalled();
+    });
+
+    it("should render calendar with range selection", async () => {
+        const { container } = render(<DatePicker selectRange />);
+
+        userEvent.click(screen.getByText("10"));
+        userEvent.click(screen.getByText("12"));
+
+        await waitFor(() => {
+            expect(container).toMatchSnapshot();
+        });
+    });
+
+    it("should render calendar with double navigation if next2Label and prev2Label were passed", () => {
+        const { container } = render(
+            <DatePicker next2Label={next2Label} prev2Label={prev2Label} />,
+        );
+
+        expect(container).toMatchSnapshot();
+        expect(screen.getByText(next2Label)).toBeInTheDocument();
+        expect(screen.getByText(prev2Label)).toBeInTheDocument();
+    });
+
+    it("should render calendar without navigation if showNavigation === false", () => {
+        const { container } = render(<DatePicker showNavigation={false} />);
+
+        expect(container).toMatchSnapshot();
+    });
+
+    it("should render calendar with neighboring month if showNeighboringMonth === true", () => {
+        const { container } = render(<DatePicker showNeighboringMonth />);
+
+        expect(container).toMatchSnapshot();
+    });
+});

--- a/lib/components/Atom/Calendar/date-picker.scss
+++ b/lib/components/Atom/Calendar/date-picker.scss
@@ -48,13 +48,12 @@
                     align-items: center;
                 }
             }
-            // TODO: refactor
+
             &__days {
                 &__day {
                     color: var(--component-dropdownItem-label-color-default);
                     border-radius: var(--component-dropdownItem-border-radius);
-                    width: 48px;
-                    height: 48px;
+                    height: var(--core-size-2400);
 
                     &--neighboringMonth {
                         color: var(--component-textIcon-normal-disabled);
@@ -63,13 +62,16 @@
             }
         }
 
+        // TODO: add normal style for dropdown list
         &__decade-view__years,
         &__year-view__months {
-            // TODO: add normal style for dropdown list
             flex-direction: column;
         }
 
         &__tile {
+            font-family: var(--core-fontFamily-ibmPlex-sans);
+            font-size: inherit;
+
             &:enabled:hover,
             &:enabled:focus {
                 background-color: var(
@@ -81,12 +83,6 @@
                 background: unset;
                 color: var(--component-dropdownItem-label-color-default);
                 position: relative;
-
-                // TODO: refactor
-                &:enabled:hover,
-                &:enabled:focus {
-                    background: #e6e6e6;
-                }
 
                 // TODO: refactor
                 &:after {
@@ -108,7 +104,7 @@
             &--active:enabled:hover,
             &--active:enabled:focus {
                 background-color: var(--component-dropdownItem-bg-selected);
-                color: white;
+                color: var(--component-dropdownItem-label-color-selectedWhite);
             }
         }
 

--- a/lib/components/Atom/Calendar/date-picker.scss
+++ b/lib/components/Atom/Calendar/date-picker.scss
@@ -20,7 +20,9 @@
             }
 
             &__arrow.react-calendar__navigation__prev-button,
-            &__arrow.react-calendar__navigation__next-button {
+            &__arrow.react-calendar__navigation__prev2-button,
+            &__arrow.react-calendar__navigation__next-button,
+            &__arrow.react-calendar__navigation__next2-button {
                 min-width: var(--core-size-1600);
                 text-align: center;
             }
@@ -84,22 +86,20 @@
                 color: var(--component-dropdownItem-label-color-default);
                 position: relative;
 
-                // TODO: refactor
                 &:after {
                     content: "";
-                    width: 4px;
-                    height: 4px;
+                    width: var(--core-size-200);
+                    height: var(--core-size-200);
                     border-radius: 50%;
                     position: absolute;
                     top: 70%;
-                    left: calc(50% - 2px);
+                    left: calc(50% - (var(--core-size-200) / 2));
                     background-color: var(
                         --component-dropdownItem-label-color-default
                     );
                 }
             }
 
-            // TODO: refactor
             &--active,
             &--active:enabled:hover,
             &--active:enabled:focus {

--- a/lib/components/Atom/Calendar/date-picker.scss
+++ b/lib/components/Atom/Calendar/date-picker.scss
@@ -1,0 +1,98 @@
+@import "@quill/static.scss";
+
+.quill-checkbox__date-picker {
+    border: none;
+    padding: var(--component-actionSheet-spacing-padding-md);
+    width: unset;
+
+    .react-calendar {
+        &__navigation {
+            height: var(--core-size-1200);
+            margin-bottom: var(--component-dropdownList-spacing-gap-sm);
+            gap: var(--component-dropdownList-spacing-gap-sm);
+
+            &__arrow.react-calendar__navigation__prev-button,
+            &__arrow.react-calendar__navigation__next-button {
+                min-width: 32px;
+                text-align: center;
+            }
+
+            &__label {
+                text-align: center;
+                &__labelText.react-calendar__navigation__label__labelText--from {
+                    color: var(--component-dropdownItem-label-color-default);
+                    font-family: var(
+                        --semantic-typography-body-md-regular-default-fontFamily
+                    );
+                    font-size: var(
+                        --semantic-typography-body-md-regular-default-fontSize
+                    );
+                    font-weight: var(
+                        --semantic-typography-body-md-regular-default-fontWeight
+                    );
+                    line-height: var(
+                        --semantic-typography-body-md-regular-default-lineHeight
+                    );
+                    letter-spacing: var(
+                        --semantic-typography-body-md-regular-default-letterSpacing
+                    );
+                }
+            }
+        }
+
+        &__month-view__weekdays {
+            height: var(--core-size-2400);
+            color: var(--core-color-opacity-black-300);
+            text-transform: none;
+            font-size: inherit;
+            font-weight: inherit;
+
+            &__weekday {
+                padding: 0;
+                display: flex;
+                justify-content: center;
+                align-items: center;
+            }
+        }
+
+        &__month-view__days__day {
+            color: var(--component-dropdownItem-label-color-default);
+            border-radius: var(--component-dropdownItem-border-radius);
+            width: 48px;
+            height: 48px;
+        }
+
+        &__tile {
+            &--now {
+                background: unset;
+                color: var(--component-dropdownItem-label-color-default);
+                position: relative;
+
+                &:enabled:hover,
+                &:enabled:focus {
+                    background: #e6e6e6;
+                }
+
+                &:after {
+                    content: "";
+                    width: 4px;
+                    height: 4px;
+                    border-radius: 50%;
+                    position: absolute;
+                    top: 70%;
+                    left: calc(50% - 2px);
+                    background-color: var(
+                        --component-dropdownItem-label-color-default
+                    );
+                }
+            }
+
+            &--active,
+            &--active:enabled:hover,
+            &--active:enabled:focus {
+                background-color: var(--component-dropdownItem-bg-selected);
+                color: white;
+            }
+        }
+    }
+}

--- a/lib/components/Atom/Calendar/date-picker.scss
+++ b/lib/components/Atom/Calendar/date-picker.scss
@@ -80,9 +80,11 @@
             flex-direction: column;
         }
 
-        &__year-view .react-calendar__tile {
-            padding: 0px var(--component-actionSheet-spacing-padding-md);
-            min-height: var(--core-size-2400);
+        &__year-view {
+            & .react-calendar__tile {
+                padding: 0px var(--component-actionSheet-spacing-padding-md);
+                min-height: var(--core-size-2400);
+            }
         }
 
         &__tile {
@@ -143,10 +145,9 @@
             }
         }
 
-        // TODO: refactor
         &__viewContainer {
             overflow-y: auto;
-            // height: 242.22px;
+            aspect-ratio: 1.12;
         }
     }
 

--- a/lib/components/Atom/Calendar/date-picker.scss
+++ b/lib/components/Atom/Calendar/date-picker.scss
@@ -1,5 +1,3 @@
-@import "@quill/quill.scss";
-
 .quill-date-picker {
     border: none;
     padding: var(--component-actionSheet-spacing-padding-md);

--- a/lib/components/Atom/Calendar/date-picker.scss
+++ b/lib/components/Atom/Calendar/date-picker.scss
@@ -4,8 +4,18 @@
     border: none;
     padding: var(--component-actionSheet-spacing-padding-md);
     background-color: var(--semantic-color-slate-solid-surface-frame-low);
-    //TODO: refactor after adding container
     width: unset;
+
+    &__wrapper {
+        width: 100%;
+        &--fixed-width {
+            width: 304px;
+
+            @media (max-width: 330px) {
+                width: 280px;
+            }
+        }
+    }
 
     .react-calendar {
         &__navigation {
@@ -55,7 +65,8 @@
                 &__day {
                     color: var(--component-dropdownItem-label-color-default);
                     border-radius: var(--component-dropdownItem-border-radius);
-                    height: var(--core-size-2400);
+                    // aspect-ratio make will make height and width equal. It's important as width is calculated.
+                    aspect-ratio: 1 / 1;
 
                     &--neighboringMonth {
                         color: var(--component-textIcon-normal-disabled);
@@ -111,7 +122,7 @@
         // TODO: refactor
         &__viewContainer {
             overflow-y: auto;
-            height: 288px;
+            // height: 288px;
         }
     }
 

--- a/lib/components/Atom/Calendar/date-picker.scss
+++ b/lib/components/Atom/Calendar/date-picker.scss
@@ -30,28 +30,37 @@
             }
         }
 
-        // TODO: refactor
-        &__month-view__weekdays {
-            height: var(--core-size-2400);
-            color: var(--core-color-opacity-black-300);
-            text-transform: none;
-            font-size: inherit;
-            font-weight: inherit;
+        &__month-view {
+            &__weekdays {
+                height: var(--core-size-2400);
+                color: var(--component-textIcon-normal-disabled);
+                text-transform: none;
+                font-family: var(--core-fontFamily-ibmPlex-sans);
+                font-size: var(--core-fontSize-100);
+                font-weight: var(--core-fontWeight-regular);
+                line-height: var(--core-lineHeight-300);
+                letter-spacing: normal;
 
-            &__weekday {
-                padding: 0;
-                display: flex;
-                justify-content: center;
-                align-items: center;
+                &__weekday {
+                    padding: 0;
+                    display: flex;
+                    justify-content: center;
+                    align-items: center;
+                }
             }
-        }
+            // TODO: refactor
+            &__days {
+                &__day {
+                    color: var(--component-dropdownItem-label-color-default);
+                    border-radius: var(--component-dropdownItem-border-radius);
+                    width: 48px;
+                    height: 48px;
 
-        // TODO: refactor
-        &__month-view__days__day {
-            color: var(--component-dropdownItem-label-color-default);
-            border-radius: var(--component-dropdownItem-border-radius);
-            width: 48px;
-            height: 48px;
+                    &--neighboringMonth {
+                        color: var(--component-textIcon-normal-disabled);
+                    }
+                }
+            }
         }
 
         &__decade-view__years,

--- a/lib/components/Atom/Calendar/date-picker.scss
+++ b/lib/components/Atom/Calendar/date-picker.scss
@@ -3,6 +3,7 @@
 .quill-date-picker {
     border: none;
     padding: var(--component-actionSheet-spacing-padding-md);
+    background-color: var(--semantic-color-slate-solid-surface-frame-low);
     //TODO: refactor after adding container
     width: unset;
 
@@ -10,6 +11,13 @@
         &__navigation {
             height: var(--core-size-1600);
             margin-bottom: var(--semantic-spacing-general-md);
+
+            button:enabled:hover,
+            button:enabled:focus {
+                background-color: var(
+                    --semantic-color-monochrome-surface-normal-low
+                );
+            }
 
             &__arrow.react-calendar__navigation__prev-button,
             &__arrow.react-calendar__navigation__next-button {
@@ -22,6 +30,7 @@
             }
         }
 
+        // TODO: refactor
         &__month-view__weekdays {
             height: var(--core-size-2400);
             color: var(--core-color-opacity-black-300);
@@ -37,6 +46,7 @@
             }
         }
 
+        // TODO: refactor
         &__month-view__days__day {
             color: var(--component-dropdownItem-label-color-default);
             border-radius: var(--component-dropdownItem-border-radius);
@@ -51,16 +61,25 @@
         }
 
         &__tile {
+            &:enabled:hover,
+            &:enabled:focus {
+                background-color: var(
+                    --semantic-color-monochrome-surface-normal-low
+                );
+            }
+
             &--now {
                 background: unset;
                 color: var(--component-dropdownItem-label-color-default);
                 position: relative;
 
+                // TODO: refactor
                 &:enabled:hover,
                 &:enabled:focus {
                     background: #e6e6e6;
                 }
 
+                // TODO: refactor
                 &:after {
                     content: "";
                     width: 4px;
@@ -75,6 +94,7 @@
                 }
             }
 
+            // TODO: refactor
             &--active,
             &--active:enabled:hover,
             &--active:enabled:focus {
@@ -83,6 +103,7 @@
             }
         }
 
+        // TODO: refactor
         &__viewContainer {
             overflow-y: auto;
             height: 288px;

--- a/lib/components/Atom/Calendar/date-picker.scss
+++ b/lib/components/Atom/Calendar/date-picker.scss
@@ -1,6 +1,6 @@
-@import "@quill/static.scss";
+@import "@quill/quill.scss";
 
-.quill-checkbox__date-picker {
+.quill-date-picker {
     border: none;
     padding: var(--component-actionSheet-spacing-padding-md);
     width: unset;
@@ -62,6 +62,11 @@
             height: 48px;
         }
 
+        &__decade-view__years,
+        &__year-view__months {
+            flex-direction: column;
+        }
+
         &__tile {
             &--now {
                 background: unset;
@@ -94,5 +99,14 @@
                 color: white;
             }
         }
+
+        &__viewContainer {
+            overflow-y: auto;
+            height: 288px;
+        }
+    }
+
+    abbr[title] {
+        text-decoration: none;
     }
 }

--- a/lib/components/Atom/Calendar/date-picker.scss
+++ b/lib/components/Atom/Calendar/date-picker.scss
@@ -134,6 +134,13 @@
                 color: var(--component-dropdownItem-label-color-default);
                 position: relative;
 
+                &.react-calendar__tile--hover,
+                &:enabled:hover,
+                &:enabled:focus {
+                    background-color: var(
+                        --semantic-color-monochrome-surface-normal-low
+                    );
+                }
                 &:after {
                     content: "";
                     width: var(--core-size-200);

--- a/lib/components/Atom/Calendar/date-picker.scss
+++ b/lib/components/Atom/Calendar/date-picker.scss
@@ -8,10 +8,10 @@
 
     &__wrapper {
         &--fixed-width {
-            width: 304px;
+            width: var(--component-dropdownList-width-dateRangePicker-sm);
 
             @media (max-width: 330px) {
-                width: 280px;
+                width: 290px;
             }
         }
     }
@@ -65,7 +65,7 @@
                     color: var(--component-dropdownItem-label-color-default);
                     border-radius: var(--component-dropdownItem-border-radius);
                     // aspect-ratio make will make height and width equal. It's important as width is calculated.
-                    aspect-ratio: 1 / 1;
+                    aspect-ratio: 1;
 
                     &--neighboringMonth {
                         color: var(--component-textIcon-normal-disabled);
@@ -74,16 +74,19 @@
             }
         }
 
-        // TODO: add normal style for dropdown list
+        &__century-view__decades,
         &__decade-view__years,
         &__year-view__months {
             flex-direction: column;
         }
 
-        &__year-view {
+        &__year-view,
+        &__decade-view,
+        &__century-view {
             & .react-calendar__tile {
                 padding: 0px var(--component-actionSheet-spacing-padding-md);
                 min-height: var(--core-size-2400);
+                border-radius: var(--component-dropdownItem-border-radius);
             }
         }
 
@@ -139,7 +142,9 @@
 
             &--active,
             &--active:enabled:hover,
-            &--active:enabled:focus {
+            &--active:enabled:focus,
+            &--hasActive,
+            &--hasActive:enabled:hover {
                 background-color: var(--component-dropdownItem-bg-selected);
                 color: var(--component-dropdownItem-label-color-selectedWhite);
             }
@@ -147,7 +152,7 @@
 
         &__viewContainer {
             overflow-y: auto;
-            aspect-ratio: 1.12;
+            aspect-ratio: 1.16;
         }
     }
 

--- a/lib/components/Atom/Calendar/date-picker.scss
+++ b/lib/components/Atom/Calendar/date-picker.scss
@@ -3,40 +3,22 @@
 .quill-date-picker {
     border: none;
     padding: var(--component-actionSheet-spacing-padding-md);
+    //TODO: refactor after adding container
     width: unset;
 
     .react-calendar {
         &__navigation {
-            height: var(--core-size-1200);
-            margin-bottom: var(--component-dropdownList-spacing-gap-sm);
-            gap: var(--component-dropdownList-spacing-gap-sm);
+            height: var(--core-size-1600);
+            margin-bottom: var(--semantic-spacing-general-md);
 
             &__arrow.react-calendar__navigation__prev-button,
             &__arrow.react-calendar__navigation__next-button {
-                min-width: 32px;
+                min-width: var(--core-size-1600);
                 text-align: center;
             }
 
             &__label {
                 text-align: center;
-                &__labelText.react-calendar__navigation__label__labelText--from {
-                    color: var(--component-dropdownItem-label-color-default);
-                    font-family: var(
-                        --semantic-typography-body-md-regular-default-fontFamily
-                    );
-                    font-size: var(
-                        --semantic-typography-body-md-regular-default-fontSize
-                    );
-                    font-weight: var(
-                        --semantic-typography-body-md-regular-default-fontWeight
-                    );
-                    line-height: var(
-                        --semantic-typography-body-md-regular-default-lineHeight
-                    );
-                    letter-spacing: var(
-                        --semantic-typography-body-md-regular-default-letterSpacing
-                    );
-                }
             }
         }
 
@@ -64,6 +46,7 @@
 
         &__decade-view__years,
         &__year-view__months {
+            // TODO: add normal style for dropdown list
             flex-direction: column;
         }
 

--- a/lib/components/Atom/Calendar/date-picker.scss
+++ b/lib/components/Atom/Calendar/date-picker.scss
@@ -7,7 +7,6 @@
     width: unset;
 
     &__wrapper {
-        width: 100%;
         &--fixed-width {
             width: 304px;
 
@@ -81,6 +80,11 @@
             flex-direction: column;
         }
 
+        &__year-view .react-calendar__tile {
+            padding: 0px var(--component-actionSheet-spacing-padding-md);
+            min-height: var(--core-size-2400);
+        }
+
         &__tile {
             font-family: var(--core-fontFamily-ibmPlex-sans);
             font-size: inherit;
@@ -89,6 +93,26 @@
             &:enabled:focus {
                 background-color: var(
                     --semantic-color-monochrome-surface-normal-low
+                );
+            }
+
+            &--range {
+                border-radius: unset;
+            }
+            &--rangeStart {
+                border-top-left-radius: var(
+                    --component-dropdownItem-border-radius
+                );
+                border-bottom-left-radius: var(
+                    --component-dropdownItem-border-radius
+                );
+            }
+            &--rangeEnd {
+                border-top-right-radius: var(
+                    --component-dropdownItem-border-radius
+                );
+                border-bottom-right-radius: var(
+                    --component-dropdownItem-border-radius
                 );
             }
 
@@ -122,7 +146,7 @@
         // TODO: refactor
         &__viewContainer {
             overflow-y: auto;
-            // height: 288px;
+            // height: 242.22px;
         }
     }
 

--- a/lib/components/Atom/Calendar/date-picker.scss
+++ b/lib/components/Atom/Calendar/date-picker.scss
@@ -152,7 +152,7 @@
 
         &__viewContainer {
             overflow-y: auto;
-            aspect-ratio: 1.16;
+            aspect-ratio: 1.12;
         }
     }
 

--- a/lib/components/Atom/Calendar/date-picker.scss
+++ b/lib/components/Atom/Calendar/date-picker.scss
@@ -87,6 +87,14 @@
                 padding: 0px var(--component-actionSheet-spacing-padding-md);
                 min-height: var(--core-size-2400);
                 border-radius: var(--component-dropdownItem-border-radius);
+                color: var(--component-dropdownItem-label-color-default);
+
+                &--hasActive,
+                &--hasActive:enabled:hover {
+                    color: var(
+                        --component-dropdownItem-label-color-selectedWhite
+                    );
+                }
             }
         }
 

--- a/lib/components/Atom/Calendar/date-picker.stories.tsx
+++ b/lib/components/Atom/Calendar/date-picker.stories.tsx
@@ -353,6 +353,17 @@ const meta = {
             options: ["true", "false"],
             control: { type: "boolean" },
         },
+        showNavigation: {
+            table: {
+                type: {
+                    summary: "boolean | undefined",
+                },
+            },
+            description:
+                "Whether a navigation bar with arrows and title shall be rendered. Default value: true.",
+            options: ["true", "false"],
+            control: { type: "boolean" },
+        },
     },
 } satisfies Meta<typeof DatePicker>;
 

--- a/lib/components/Atom/Calendar/date-picker.stories.tsx
+++ b/lib/components/Atom/Calendar/date-picker.stories.tsx
@@ -456,6 +456,17 @@ const meta = {
                 "Class name(s) that will be applied to a given calendar item (day on month view, month on year view and so on).",
             control: { type: "text" },
         },
+        value: {
+            table: {
+                type: {
+                    summary:
+                        "string | Date | null | (string | Date | null)[] | undefined",
+                },
+            },
+            description:
+                "Calendar value. Can be either one value or an array of two values. If you wish to use react-calendar in an uncontrolled way, use defaultValue instead.",
+            control: { type: null },
+        },
         wrapperClassName: {
             table: {
                 type: {
@@ -472,7 +483,6 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 const Template: React.FC<Template> = ({ ...args }: Template) => {
-    const [date, setDate] = useState<Template["value"]>(new Date());
     const [formattedDate, setFormattedDate] = useState("");
 
     return (
@@ -481,8 +491,6 @@ const Template: React.FC<Template> = ({ ...args }: Template) => {
             <div style={{ width: `${args.isWidthFixed ? "312px" : "90vw"}` }}>
                 <DatePicker
                     {...args}
-                    value={date}
-                    onChange={(value) => setDate(value)}
                     onFormattedDate={(value) => setFormattedDate(value)}
                 />
             </div>
@@ -496,6 +504,12 @@ export const DatePickerWithRangeSelection = Template.bind(this) as Story;
 DatePickerWithRangeSelection.args = {
     ...meta.args,
     selectRange: true,
+};
+
+export const DatePickerWithSelectedValuePassed = Template.bind(this) as Story;
+DatePickerWithSelectedValuePassed.args = {
+    ...meta.args,
+    value: new Date(),
 };
 
 export const DatePickerWithDoubleNavigation = Template.bind(this) as Story;

--- a/lib/components/Atom/Calendar/date-picker.stories.tsx
+++ b/lib/components/Atom/Calendar/date-picker.stories.tsx
@@ -108,4 +108,8 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const DefaultDatePicker: Story = {};
+export const DefaultDatePicker: Story = {
+    args: {
+        className: "quill-checkbox__date-picker",
+    },
+};

--- a/lib/components/Atom/Calendar/date-picker.stories.tsx
+++ b/lib/components/Atom/Calendar/date-picker.stories.tsx
@@ -478,7 +478,7 @@ const Template: React.FC<Template> = ({ ...args }: Template) => {
     return (
         <>
             <Text as="div">Selected date: {formattedDate}</Text>
-            <div style={{ width: `${args.isWidthFixed ? "304px" : "90vw"}` }}>
+            <div style={{ width: `${args.isWidthFixed ? "312px" : "90vw"}` }}>
                 <DatePicker
                     {...args}
                     value={date}

--- a/lib/components/Atom/Calendar/date-picker.stories.tsx
+++ b/lib/components/Atom/Calendar/date-picker.stories.tsx
@@ -2,6 +2,8 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 import { Text } from "@components/Typography";
 import {
+    LabelPairedChevronRightSmFillIcon,
+    LabelPairedChevronLeftSmFillIcon,
     LabelPairedChevronsRightSmFillIcon,
     LabelPairedChevronsLeftSmFillIcon,
 } from "@deriv/quill-icons";
@@ -22,6 +24,36 @@ const meta = {
         },
     },
     tags: ["autodocs"],
+    args: {
+        allowPartialRange: false,
+        isWidthFixed: true,
+        formatMonthYear: (locale, date) =>
+            new Date(date).toLocaleString(locale || navigator.languages, {
+                month: "short",
+                year: "numeric",
+            }),
+        goToRangeStartOnSelect: true,
+        maxDetail: "month",
+        minDetail: "century",
+        navigationLabel: ({ label }) => <Text as="span">{label}</Text>,
+        next2Label: null,
+        nextLabel: (
+            <LabelPairedChevronRightSmFillIcon fill="var(--component-textIcon-normal-prominent)" />
+        ),
+        optionsConfig: {
+            day: "2-digit",
+            month: "2-digit",
+            year: "numeric",
+        },
+        prev2Label: null,
+        prevLabel: (
+            <LabelPairedChevronLeftSmFillIcon fill="var(--component-textIcon-normal-prominent)" />
+        ),
+        returnValue: "start",
+        selectRange: false,
+        showNavigation: true,
+        showNeighboringMonth: false,
+    },
     argTypes: {
         activeStartDate: {
             table: { type: { summary: "Date | undefined" } },
@@ -446,25 +478,29 @@ const Template: React.FC<Template> = ({ ...args }: Template) => {
     return (
         <>
             <Text as="div">Selected date: {formattedDate}</Text>
-            <DatePicker
-                {...args}
-                value={date}
-                onChange={(value) => setDate(value)}
-                onFormattedDate={(value) => setFormattedDate(value)}
-            />
+            <div style={{ width: `${args.isWidthFixed ? "304px" : "90vw"}` }}>
+                <DatePicker
+                    {...args}
+                    value={date}
+                    onChange={(value) => setDate(value)}
+                    onFormattedDate={(value) => setFormattedDate(value)}
+                />
+            </div>
         </>
     );
 };
 export const DefaultDatePicker = Template.bind(this) as Story;
-DefaultDatePicker.args = {};
+DefaultDatePicker.args = { ...meta.args };
 
 export const DatePickerWithRangeSelection = Template.bind(this) as Story;
 DatePickerWithRangeSelection.args = {
+    ...meta.args,
     selectRange: true,
 };
 
 export const DatePickerWithDoubleNavigation = Template.bind(this) as Story;
 DatePickerWithDoubleNavigation.args = {
+    ...meta.args,
     next2Label: (
         <LabelPairedChevronsRightSmFillIcon fill="var(--component-textIcon-normal-prominent)" />
     ),
@@ -476,6 +512,7 @@ DatePickerWithDoubleNavigation.args = {
 export const DatePickerWithCustomConfigForFormattingSelectedDate =
     Template.bind(this) as Story;
 DatePickerWithCustomConfigForFormattingSelectedDate.args = {
+    ...meta.args,
     optionsConfig: {
         day: "numeric",
         month: "short",
@@ -487,6 +524,7 @@ export const DatePickerWithCustomMonthAndYearFormatting = Template.bind(
     this,
 ) as Story;
 DatePickerWithCustomMonthAndYearFormatting.args = {
+    ...meta.args,
     formatMonthYear: (locale, date) =>
         new Date(date).toLocaleString(locale || navigator.languages, {
             month: "2-digit",
@@ -496,30 +534,36 @@ DatePickerWithCustomMonthAndYearFormatting.args = {
 
 export const DatePickerWithoutNavigation = Template.bind(this) as Story;
 DatePickerWithoutNavigation.args = {
+    ...meta.args,
     showNavigation: false,
 };
 
 export const DatePickerWithNeighboringMonth = Template.bind(this) as Story;
 DatePickerWithNeighboringMonth.args = {
+    ...meta.args,
     showNeighboringMonth: true,
 };
 
 export const DatePickerWithCustomActiveStartDate = Template.bind(this) as Story;
 DatePickerWithCustomActiveStartDate.args = {
+    ...meta.args,
     activeStartDate: new Date(2017, 0, 1),
 };
 
 export const DatePickerGregoryType = Template.bind(this) as Story;
 DatePickerGregoryType.args = {
+    ...meta.args,
     calendarType: "gregory",
 };
 
 export const DatePickerIslamicType = Template.bind(this) as Story;
 DatePickerIslamicType.args = {
+    ...meta.args,
     calendarType: "islamic",
 };
 
 export const DatePickerWithNotFixedWidth = Template.bind(this) as Story;
 DatePickerWithNotFixedWidth.args = {
+    ...meta.args,
     isWidthFixed: false,
 };

--- a/lib/components/Atom/Calendar/date-picker.stories.tsx
+++ b/lib/components/Atom/Calendar/date-picker.stories.tsx
@@ -78,6 +78,17 @@ const meta = {
             options: ["month", "year", "decade", "century"],
             control: { type: "radio" },
         },
+        isWidthFixed: {
+            table: {
+                type: {
+                    summary: "boolean | undefined",
+                },
+            },
+            description:
+                "Determines if width should be fixed or equal to container width. Default value - true",
+            options: ["true", "false"],
+            control: { type: "boolean" },
+        },
         formatDay: {
             table: {
                 type: {
@@ -413,6 +424,15 @@ const meta = {
                 "Class name(s) that will be applied to a given calendar item (day on month view, month on year view and so on).",
             control: { type: "text" },
         },
+        wrapperClassName: {
+            table: {
+                type: {
+                    summary: "string | undefined",
+                },
+            },
+            description: "Class that will be applied to a calendar wrapper",
+            control: { type: "text" },
+        },
     },
 } satisfies Meta<typeof DatePicker>;
 
@@ -497,4 +517,9 @@ DatePickerGregoryType.args = {
 export const DatePickerIslamicType = Template.bind(this) as Story;
 DatePickerIslamicType.args = {
     calendarType: "islamic",
+};
+
+export const DatePickerWithNotFixedWidth = Template.bind(this) as Story;
+DatePickerWithNotFixedWidth.args = {
+    isWidthFixed: false,
 };

--- a/lib/components/Atom/Calendar/date-picker.stories.tsx
+++ b/lib/components/Atom/Calendar/date-picker.stories.tsx
@@ -112,7 +112,7 @@ const meta = {
                 },
             },
             description:
-                "Function called to override default formatting of months and years. Can be used to use your own formatting function. Default formatter is used if nothing was passed. Example: (locale, date) => formatDate(date, 'MMMM YYYY')",
+                "Function called to override default formatting of months and years. Can be used to use your own formatting function. Default formatter: (locale, date) => new Date(date).toLocaleString(locale || navigator.languages, { month: 'short', year: 'numeric' })`. Example: (locale, date) => formatDate(date, 'MMMM YYYY')",
             control: { type: null },
         },
         formatShortWeekday: {
@@ -221,7 +221,16 @@ const meta = {
             },
             description:
                 "aria-live attribute of a label rendered on calendar navigation bar. Example: 'polite'.",
+            options: ["off", "polite", "assertive"],
             control: { type: "radio" },
+        },
+        navigationLabel: {
+            table: {
+                type: { summary: "NavigationLabelFunc | undefined" },
+            },
+            description:
+                "Content of a label rendered on calendar navigation bar.",
+            control: { type: null },
         },
     },
 } satisfies Meta<typeof DatePicker>;

--- a/lib/components/Atom/Calendar/date-picker.stories.tsx
+++ b/lib/components/Atom/Calendar/date-picker.stories.tsx
@@ -4,17 +4,23 @@ import { DatePicker } from "./index";
 const meta = {
     title: "Components/Atom/DatePicker",
     component: DatePicker,
-    parameters: { layout: "centered" },
-    tags: ["autodocs"],
-    args: {
-        // activeStartDate: new Date(2017, 0, 1),
+    parameters: {
+        layout: "centered",
+        docs: {
+            description: {
+                component:
+                    "*NOTE: this component was created with the help of React Component library. [Repository Link](https://github.com/wojtekmaj/react-calendar)",
+            },
+        },
     },
+    tags: ["autodocs"],
+    args: {},
     argTypes: {
         activeStartDate: {
             table: { type: { summary: "Date | undefined" } },
             description:
                 "The beginning of a period that shall be displayed. If you wish to use react-calendar in an uncontrolled way, use defaultActiveStartDate instead. Default value - today. Example values: new Date(2017, 0, 1).",
-            control: { type: "date" },
+            control: { type: null },
         },
         allowPartialRange: {
             table: { type: { summary: "boolean | undefined" } },
@@ -31,77 +37,192 @@ const meta = {
                 },
             },
             description:
-                "Type of calendar that should be used. Can be 'gregory, 'hebrew', 'islamic', 'iso8601'. Setting to 'gregory' or 'hebrew' will change the first day of the week to Sunday. Setting to 'islamic' will change the first day of the week to Saturday. Setting to 'islamic' or 'hebrew' will make weekends appear on Friday to Saturday. Default value - type of calendar most commonly used in a given locale.",
+                "Type of calendar that should be used. Can be 'gregory', 'hebrew', 'islamic', 'iso8601'. Setting to 'gregory' or 'hebrew' will change the first day of the week to Sunday. Setting to 'islamic' will change the first day of the week to Saturday. Setting to 'islamic' or 'hebrew' will make weekends appear on Friday to Saturday. Default value - type of calendar most commonly used in a given locale.",
             options: ["gregory", "hebrew", "islamic", "iso8601"],
-            control: { type: "string" },
+            control: { type: "radio" },
         },
-        // disabled: {
-        //     table: { type: { summary: "boolean | undefined" } },
-        //     description: "Flag for setting accessibility",
-        //     options: ["true", "false"],
-        //     control: { type: "boolean" },
-        // },
-        // indeterminate: {
-        //     table: { type: { summary: "boolean | undefined" } },
-        //     description: "Flag for setting indeterminate state",
-        //     options: ["true", "false"],
-        //     control: { type: "boolean" },
-        // },
-        // infoIconClassName: {
-        //     table: { type: { summary: "string | undefined" } },
-        //     description: "ClassName for info icon",
-        //     control: { type: "text" },
-        // },
-        // showInfoIcon: {
-        //     table: { type: { summary: "boolean | undefined" } },
-        //     description: "Flag for adding info icon",
-        //     options: ["true", "false"],
-        //     control: { type: "boolean" },
-        // },
-        // size: {
-        //     table: { type: { summary: "string | undefined" } },
-        //     description: "Size of the label and info icon",
-        //     options: ["sm", "md"],
-        //     control: { type: "radio" },
-        // },
-        // label: {
-        //     table: { type: { summary: "React.Node" } },
-        //     description: "Label content (string or React.Node)",
-        //     control: { type: "text" },
-        // },
-        // labelClassName: {
-        //     table: { type: { summary: "string | undefined" } },
-        //     description:
-        //         "ClassName for label, which will be passed to Text component",
-        //     control: { type: "text" },
-        // },
-        // name: {
-        //     table: { type: { summary: "string | undefined" } },
-        //     description:
-        //         "Input attribute value. Is used as one of the ways to bind input tag with its label",
-        //     control: { type: "text" },
-        // },
-        // className: {
-        //     table: { type: { summary: "string | undefined" } },
-        //     description: "ClassName for external tag of the component",
-        //     control: { type: "text" },
-        // },
-        // onChange: {
-        //     table: { type: { summary: "function | undefined" } },
-        //     description:
-        //         "Callback function, which will be called as a part of onChange and onKeyDown",
-        //     control: { type: null },
-        // },
-        // id: {
-        //     table: { type: { summary: "string | undefined" } },
-        //     description:
-        //         "Input attribute value. Is used as one of the ways to bind input tag with its label",
-        //     control: { type: "text" },
-        // },
-        // ref: {
-        //     description: "Reference for direct manipulations",
-        //     control: { type: null },
-        // },
+        className: {
+            table: { type: { summary: "string | undefined" } },
+            description:
+                "Class name(s) that will be added along with 'react-calendar' to the main react-calendar <div> element.",
+            control: { type: "text" },
+        },
+        defaultActiveStartDate: {
+            table: { type: { summary: "Date | undefined" } },
+            description:
+                "The beginning of a period that shall be displayed by default. If you wish to use react-calendar in a controlled way, use activeStartDate instead. Default value - today. Example values: new Date(2017, 0, 1).",
+            control: { type: null },
+        },
+        defaultValue: {
+            table: { type: { summary: "Date | Date[] | undefined" } },
+            description:
+                "Calendar value that shall be selected initially. Can be either one value or an array of two values. If you wish to use react-calendar in a controlled way, use value instead. Example values: new Date(2017, 0, 1) or [new Date(2017, 0, 1), new Date(2017, 7, 1)].",
+            control: { type: null },
+        },
+        defaultView: {
+            table: {
+                type: {
+                    summary:
+                        "'month'| 'year'| 'decade' | 'century' | undefined",
+                },
+            },
+            description:
+                "Determines which calendar view shall be opened initially. Does not disable navigation. Can be 'month', 'year', 'decade' or 'century'. If you wish to use react-calendar in a controlled way, use view instead. Default value - The most detailed view allowed.",
+            options: ["month", "year", "decade", "century"],
+            control: { type: "radio" },
+        },
+        formatDay: {
+            table: {
+                type: {
+                    summary:
+                        "((locale: string | undefined, date: Date) => string) | undefined",
+                },
+            },
+            description:
+                "Function called to override default formatting of day tile labels. Can be used to use your own formatting function. Default formatter is used if nothing was passed. Example: (locale, date) => formatDate(date, 'd')",
+            control: { type: null },
+        },
+        formatLongDate: {
+            table: {
+                type: {
+                    summary:
+                        "((locale: string | undefined, date: Date) => string) | undefined",
+                },
+            },
+            description:
+                "Function called to override default formatting of day tile abbr labels. Can be used to use your own formatting function. Default formatter is used if nothing was passed. Example: (locale, date) => formatDate(date, 'dd MMM YYYY')",
+            control: { type: null },
+        },
+        formatMonth: {
+            table: {
+                type: {
+                    summary:
+                        "((locale: string | undefined, date: Date) => string) | undefined",
+                },
+            },
+            description:
+                "Function called to override default formatting of month names. Can be used to use your own formatting function. Default formatter is used if nothing was passed. Example: (locale, date) => formatDate(date, 'MMM')",
+            control: { type: null },
+        },
+        formatMonthYear: {
+            table: {
+                type: {
+                    summary:
+                        "((locale: string | undefined, date: Date) => string) | undefined",
+                },
+            },
+            description:
+                "Function called to override default formatting of months and years. Can be used to use your own formatting function. Default formatter is used if nothing was passed. Example: (locale, date) => formatDate(date, 'MMMM YYYY')",
+            control: { type: null },
+        },
+        formatShortWeekday: {
+            table: {
+                type: {
+                    summary:
+                        "((locale: string | undefined, date: Date) => string) | undefined",
+                },
+            },
+            description:
+                "Function called to override default formatting of weekday names (shortened). Can be used to use your own formatting function. Default formatter is used if nothing was passed. Example: (locale, date) => formatDate(date, 'dd')",
+            control: { type: null },
+        },
+        formatWeekday: {
+            table: {
+                type: {
+                    summary:
+                        "((locale: string | undefined, date: Date) => string) | undefined",
+                },
+            },
+            description:
+                "Function called to override default formatting of weekday names. Can be used to use your own formatting function. Default formatter is used if nothing was passed. Example: (locale, date) => formatDate(date, 'dd')",
+            control: { type: null },
+        },
+        formatYear: {
+            table: {
+                type: {
+                    summary:
+                        "((locale: string | undefined, date: Date) => string) | undefined",
+                },
+            },
+            description:
+                "Function called to override default formatting of year in the top navigation section. Can be used to use your own formatting function. Default formatter is used if nothing was passed. Example: (locale, date) => formatDate(date, 'YYYY')",
+            control: { type: null },
+        },
+        goToRangeStartOnSelect: {
+            table: { type: { summary: "boolean | undefined" } },
+            description:
+                "Whether to go to the beginning of the range when selecting the end of the range. Default value - true.",
+            options: ["true", "false"],
+            control: { type: "boolean" },
+        },
+        inputRef: {
+            table: {
+                type: { summary: "React.Ref<HTMLDivElement> | undefined" },
+            },
+            description:
+                "A prop that behaves like ref, but it's passed to main 'div' rendered by 'Calendar' component.",
+            control: { type: null },
+        },
+        locale: {
+            table: {
+                type: { summary: "string | undefined" },
+            },
+            description:
+                "Locale that should be used by the calendar. Can be any IETF language tag. Note: When using SSR, setting this prop may help resolving hydration errors caused by locale mismatch between server and client. Default value: server locale/User's browser settings. Example: 'hu-HU'.",
+            control: { type: "text" },
+        },
+        maxDate: {
+            table: { type: { summary: "Date | undefined" } },
+            description:
+                "Maximum date that the user can select. Periods partially overlapped by maxDate will also be selectable, although react-calendar will ensure that no later date is selected. Example values: new Date().",
+            control: { type: null },
+        },
+        maxDetail: {
+            table: {
+                type: {
+                    summary:
+                        "'month'| 'year'| 'decade' | 'century' | undefined",
+                },
+            },
+            description:
+                "The most detailed view that the user shall see. View defined here also becomes the one on which clicking an item will select a date and pass it to onChange. Can be 'month', 'year', 'decade' or 'century'. Default value - 'month'.",
+            options: ["month", "year", "decade", "century"],
+            control: { type: "radio" },
+        },
+        minDate: {
+            table: { type: { summary: "Date | undefined" } },
+            description:
+                "Minimum date that the user can select. Periods partially overlapped by minDate will also be selectable, although react-calendar will ensure that no earlier date is selected. Example values: new Date().",
+            control: { type: null },
+        },
+        minDetail: {
+            table: {
+                type: {
+                    summary:
+                        "'month'| 'year'| 'decade' | 'century' | undefined",
+                },
+            },
+            description:
+                "The least detailed view that the user shall see. Default value - 'century'.",
+            options: ["month", "year", "decade", "century"],
+            control: { type: "radio" },
+        },
+        navigationAriaLabel: {
+            table: {
+                type: { summary: "string | undefined" },
+            },
+            description:
+                "aria-label attribute of a label rendered on calendar navigation bar. Example: 'Go up'.",
+            control: { type: "text" },
+        },
+        navigationAriaLive: {
+            table: {
+                type: { summary: "'off' | 'polite' | 'assertive' | undefined" },
+            },
+            description:
+                "aria-live attribute of a label rendered on calendar navigation bar. Example: 'polite'.",
+            control: { type: "radio" },
+        },
     },
 } satisfies Meta<typeof DatePicker>;
 
@@ -109,7 +230,5 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const DefaultDatePicker: Story = {
-    args: {
-        className: "quill-checkbox__date-picker",
-    },
+    args: {},
 };

--- a/lib/components/Atom/Calendar/date-picker.stories.tsx
+++ b/lib/components/Atom/Calendar/date-picker.stories.tsx
@@ -364,6 +364,17 @@ const meta = {
             options: ["true", "false"],
             control: { type: "boolean" },
         },
+        showNeighboringMonth: {
+            table: {
+                type: {
+                    summary: "boolean | undefined",
+                },
+            },
+            description:
+                "Whether days from previous or next month shall be rendered if the month doesn't start on the first day of the week or doesn't end on the last day of the week, respectively. Default value: false.",
+            options: ["true", "false"],
+            control: { type: "boolean" },
+        },
     },
 } satisfies Meta<typeof DatePicker>;
 

--- a/lib/components/Atom/Calendar/date-picker.stories.tsx
+++ b/lib/components/Atom/Calendar/date-picker.stories.tsx
@@ -1,0 +1,111 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { DatePicker } from "./index";
+
+const meta = {
+    title: "Components/Atom/DatePicker",
+    component: DatePicker,
+    parameters: { layout: "centered" },
+    tags: ["autodocs"],
+    args: {
+        // activeStartDate: new Date(2017, 0, 1),
+    },
+    argTypes: {
+        activeStartDate: {
+            table: { type: { summary: "Date | undefined" } },
+            description:
+                "The beginning of a period that shall be displayed. If you wish to use react-calendar in an uncontrolled way, use defaultActiveStartDate instead. Default value - today. Example values: new Date(2017, 0, 1).",
+            control: { type: "date" },
+        },
+        allowPartialRange: {
+            table: { type: { summary: "boolean | undefined" } },
+            description:
+                "Whether to call onChange with only partial result given selectRange prop. Default value - false.",
+            options: ["true", "false"],
+            control: { type: "boolean" },
+        },
+        calendarType: {
+            table: {
+                type: {
+                    summary:
+                        "'gregory' | 'hebrew' | 'islamic' | 'iso8601' | undefined",
+                },
+            },
+            description:
+                "Type of calendar that should be used. Can be 'gregory, 'hebrew', 'islamic', 'iso8601'. Setting to 'gregory' or 'hebrew' will change the first day of the week to Sunday. Setting to 'islamic' will change the first day of the week to Saturday. Setting to 'islamic' or 'hebrew' will make weekends appear on Friday to Saturday. Default value - type of calendar most commonly used in a given locale.",
+            options: ["gregory", "hebrew", "islamic", "iso8601"],
+            control: { type: "string" },
+        },
+        // disabled: {
+        //     table: { type: { summary: "boolean | undefined" } },
+        //     description: "Flag for setting accessibility",
+        //     options: ["true", "false"],
+        //     control: { type: "boolean" },
+        // },
+        // indeterminate: {
+        //     table: { type: { summary: "boolean | undefined" } },
+        //     description: "Flag for setting indeterminate state",
+        //     options: ["true", "false"],
+        //     control: { type: "boolean" },
+        // },
+        // infoIconClassName: {
+        //     table: { type: { summary: "string | undefined" } },
+        //     description: "ClassName for info icon",
+        //     control: { type: "text" },
+        // },
+        // showInfoIcon: {
+        //     table: { type: { summary: "boolean | undefined" } },
+        //     description: "Flag for adding info icon",
+        //     options: ["true", "false"],
+        //     control: { type: "boolean" },
+        // },
+        // size: {
+        //     table: { type: { summary: "string | undefined" } },
+        //     description: "Size of the label and info icon",
+        //     options: ["sm", "md"],
+        //     control: { type: "radio" },
+        // },
+        // label: {
+        //     table: { type: { summary: "React.Node" } },
+        //     description: "Label content (string or React.Node)",
+        //     control: { type: "text" },
+        // },
+        // labelClassName: {
+        //     table: { type: { summary: "string | undefined" } },
+        //     description:
+        //         "ClassName for label, which will be passed to Text component",
+        //     control: { type: "text" },
+        // },
+        // name: {
+        //     table: { type: { summary: "string | undefined" } },
+        //     description:
+        //         "Input attribute value. Is used as one of the ways to bind input tag with its label",
+        //     control: { type: "text" },
+        // },
+        // className: {
+        //     table: { type: { summary: "string | undefined" } },
+        //     description: "ClassName for external tag of the component",
+        //     control: { type: "text" },
+        // },
+        // onChange: {
+        //     table: { type: { summary: "function | undefined" } },
+        //     description:
+        //         "Callback function, which will be called as a part of onChange and onKeyDown",
+        //     control: { type: null },
+        // },
+        // id: {
+        //     table: { type: { summary: "string | undefined" } },
+        //     description:
+        //         "Input attribute value. Is used as one of the ways to bind input tag with its label",
+        //     control: { type: "text" },
+        // },
+        // ref: {
+        //     description: "Reference for direct manipulations",
+        //     control: { type: null },
+        // },
+    },
+} satisfies Meta<typeof DatePicker>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const DefaultDatePicker: Story = {};

--- a/lib/components/Atom/Calendar/date-picker.stories.tsx
+++ b/lib/components/Atom/Calendar/date-picker.stories.tsx
@@ -26,7 +26,7 @@ const meta = {
     tags: ["autodocs"],
     args: {
         allowPartialRange: false,
-        isWidthFixed: true,
+        hasFixedWidth: true,
         formatMonthYear: (locale, date) =>
             new Date(date).toLocaleString(locale || navigator.languages, {
                 month: "short",
@@ -110,7 +110,7 @@ const meta = {
             options: ["month", "year", "decade", "century"],
             control: { type: "radio" },
         },
-        isWidthFixed: {
+        hasFixedWidth: {
             table: {
                 type: {
                     summary: "boolean | undefined",
@@ -488,7 +488,7 @@ const Template: React.FC<Template> = ({ ...args }: Template) => {
     return (
         <>
             <Text as="div">Selected date: {formattedDate}</Text>
-            <div style={{ width: `${args.isWidthFixed ? "312px" : "90vw"}` }}>
+            <div style={{ width: `${args.hasFixedWidth ? "312px" : "90vw"}` }}>
                 <DatePicker
                     {...args}
                     onFormattedDate={(value) => setFormattedDate(value)}
@@ -579,5 +579,5 @@ DatePickerIslamicType.args = {
 export const DatePickerWithNotFixedWidth = Template.bind(this) as Story;
 DatePickerWithNotFixedWidth.args = {
     ...meta.args,
-    isWidthFixed: false,
+    hasFixedWidth: false,
 };

--- a/lib/components/Atom/Calendar/date-picker.stories.tsx
+++ b/lib/components/Atom/Calendar/date-picker.stories.tsx
@@ -9,7 +9,7 @@ const meta = {
         docs: {
             description: {
                 component:
-                    "*NOTE: this component was created with the help of React Component library. [Repository Link](https://github.com/wojtekmaj/react-calendar)",
+                    "*NOTE: this component was created with the help of React Calendar library. [Repository Link](https://github.com/wojtekmaj/react-calendar)",
             },
         },
     },
@@ -226,11 +226,132 @@ const meta = {
         },
         navigationLabel: {
             table: {
-                type: { summary: "NavigationLabelFunc | undefined" },
+                type: {
+                    summary:
+                        "(({date: Date, label: string, locale: string | undefined, view: 'century' | 'decade' | 'year' | 'month'}) => React.ReactNode) | undefined",
+                },
             },
             description:
                 "Content of a label rendered on calendar navigation bar.",
             control: { type: null },
+        },
+        next2AriaLabel: {
+            table: {
+                type: { summary: "string | undefined" },
+            },
+            description:
+                "aria-label attribute of the 'next on higher level' button on the navigation pane. Example: 'Jump forwards'",
+            control: { type: "text" },
+        },
+        next2Label: {
+            table: {
+                type: {
+                    summary:
+                        "string | number | boolean | React.ReactElement<any, string | React.JSXElementConstructor<any>> | Iterable<React.ReactNode> | React.ReactPortal | null",
+                },
+            },
+            description:
+                "Content of the 'next on higher level' button on the navigation pane. Setting the value explicitly to null will hide the icon. Default value: null. Example: String: '»'",
+            control: { type: "text" },
+        },
+        nextAriaLabel: {
+            table: {
+                type: { summary: "string | undefined" },
+            },
+            description:
+                "aria-label attribute of the 'next' button on the navigation pane. Example: 'Next'",
+            control: { type: "text" },
+        },
+        nextLabel: {
+            table: {
+                type: {
+                    summary:
+                        "string | number | boolean | React.ReactElement<any, string | React.JSXElementConstructor<any>> | Iterable<React.ReactNode> | React.ReactPortal | null",
+                },
+            },
+            description:
+                "Content of the 'next' button on the navigation pane. Setting the value explicitly to null will hide the icon. Default value: LabelPairedChevronRightSmFillIcon. Example: String: '>'",
+            control: { type: "text" },
+        },
+        optionsConfig: {
+            table: {
+                type: {
+                    summary: "Record<string | string> | undefined",
+                },
+            },
+            description:
+                "Config for changing format of the selected date, will be passed inside of Date.toLocaleDateString(). Default value: {day: '2-digit', month: '2-digit', year: 'numeric'}",
+            control: { type: null },
+        },
+        onActiveStartDateChange: {
+            table: {
+                type: {
+                    summary:
+                        "(({ action: 'prev' | 'prev2' | 'next' | 'next2' | 'onChange' | 'drillUp' | 'drillDown', activeStartDate: date | null, value: Date | null, view: 'century' | 'decade' | 'year' | 'month' }) => void) | undefined",
+                },
+            },
+            description:
+                "Function called when the user navigates from one view to another using previous/next button. Note that this function will not be called when e.g. drilling up from January 2021 to 2021 or drilling down the other way around. action signifies the reason for active start date change and can be one of the following values: 'prev', 'prev2', 'next', 'next2', 'drillUp', 'drillDown', 'onChange'. Example: ({ action, activeStartDate, value, view }) => alert('Changed view to: ', activeStartDate, view)",
+            control: { type: null },
+        },
+        prev2AriaLabel: {
+            table: {
+                type: { summary: "string | undefined" },
+            },
+            description:
+                "aria-label attribute of the 'previous on higher level' button on the navigation pane. Example: 'Jump backwards'",
+            control: { type: "text" },
+        },
+        prev2Label: {
+            table: {
+                type: {
+                    summary:
+                        "string | number | boolean | React.ReactElement<any, string | React.JSXElementConstructor<any>> | Iterable<React.ReactNode> | React.ReactPortal | null",
+                },
+            },
+            description:
+                "Content of the 'previous on higher level' button on the navigation pane. Setting the value explicitly to null will hide the icon. Default value: null. Example: String: '«'",
+            control: { type: "text" },
+        },
+        prevAriaLabel: {
+            table: {
+                type: { summary: "string | undefined" },
+            },
+            description:
+                "aria-label attribute of the 'previous' button on the navigation pane. Example: 'Previous'",
+            control: { type: "text" },
+        },
+        prevLabel: {
+            table: {
+                type: {
+                    summary:
+                        "string | number | boolean | React.ReactElement<any, string | React.JSXElementConstructor<any>> | Iterable<React.ReactNode> | React.ReactPortal | null",
+                },
+            },
+            description:
+                "Content of the 'previous' button on the navigation pane. Setting the value explicitly to null will hide the icon. Default value: LabelPairedChevronLeftSmFillIcon. Example: String: '<'",
+            control: { type: "text" },
+        },
+        returnValue: {
+            table: {
+                type: {
+                    summary: "'start' | 'end' | 'range' | undefined",
+                },
+            },
+            description:
+                "Which dates shall be passed by the calendar to the onChange function and onClick{Period} functions. Can be 'start', 'end' or 'range'. The latter will cause an array with start and end values to be passed. Default value: 'start'.",
+            control: { type: "text" },
+        },
+        selectRange: {
+            table: {
+                type: {
+                    summary: "boolean | undefined",
+                },
+            },
+            description:
+                "Whether the user shall select two dates forming a range instead of just one. Note: This feature will make react-calendar return array with two dates regardless of returnValue setting. Default value: false.",
+            options: ["true", "false"],
+            control: { type: "boolean" },
         },
     },
 } satisfies Meta<typeof DatePicker>;
@@ -240,4 +361,8 @@ type Story = StoryObj<typeof meta>;
 
 export const DefaultDatePicker: Story = {
     args: {},
+};
+
+export const DatePickerWithRangeSelection: Story = {
+    args: { selectRange: true },
 };

--- a/lib/components/Atom/Calendar/date-picker.stories.tsx
+++ b/lib/components/Atom/Calendar/date-picker.stories.tsx
@@ -561,7 +561,7 @@ DatePickerWithNeighboringMonth.args = {
 export const DatePickerWithCustomActiveStartDate = Template.bind(this) as Story;
 DatePickerWithCustomActiveStartDate.args = {
     ...meta.args,
-    startDate: new Date(2017, 0, 1),
+    startDate: new Date("01/01/2017"),
 };
 
 export const DatePickerGregoryType = Template.bind(this) as Story;

--- a/lib/components/Atom/Calendar/date-picker.stories.tsx
+++ b/lib/components/Atom/Calendar/date-picker.stories.tsx
@@ -375,6 +375,16 @@ const meta = {
             options: ["true", "false"],
             control: { type: "boolean" },
         },
+        tileClassName: {
+            table: {
+                type: {
+                    summary: "string | undefined",
+                },
+            },
+            description:
+                "Class name(s) that will be applied to a given calendar item (day on month view, month on year view and so on).",
+            control: { type: "text" },
+        },
     },
 } satisfies Meta<typeof DatePicker>;
 

--- a/lib/components/Atom/Calendar/date-picker.stories.tsx
+++ b/lib/components/Atom/Calendar/date-picker.stories.tsx
@@ -1,5 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { Text } from "@components/Typography";
 import { DatePicker } from "./index";
+
+type Template = React.ComponentProps<typeof DatePicker>;
 
 const meta = {
     title: "Components/Atom/DatePicker",
@@ -9,12 +13,11 @@ const meta = {
         docs: {
             description: {
                 component:
-                    "*NOTE: this component was created with the help of React Calendar library. [Repository Link](https://github.com/wojtekmaj/react-calendar)",
+                    "*NOTE: this component was created with the help of React Calendar library. [Repository link](https://github.com/wojtekmaj/react-calendar)",
             },
         },
     },
     tags: ["autodocs"],
-    args: {},
     argTypes: {
         activeStartDate: {
             table: { type: { summary: "Date | undefined" } },
@@ -294,6 +297,27 @@ const meta = {
                 "Function called when the user navigates from one view to another using previous/next button. Note that this function will not be called when e.g. drilling up from January 2021 to 2021 or drilling down the other way around. action signifies the reason for active start date change and can be one of the following values: 'prev', 'prev2', 'next', 'next2', 'drillUp', 'drillDown', 'onChange'. Example: ({ action, activeStartDate, value, view }) => alert('Changed view to: ', activeStartDate, view)",
             control: { type: null },
         },
+        onChange: {
+            table: {
+                type: {
+                    summary:
+                        "((value: Date | null | (Date | null)[], event?: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void) | undefined",
+                },
+            },
+            description:
+                "Function called when the user clicks an item (day on month view, month on year view and so on) on the most detailed view available.",
+            control: { type: null },
+        },
+        onFormattedDate: {
+            table: {
+                type: {
+                    summary: "((value: string) => void) | undefined",
+                },
+            },
+            description:
+                "Function called when the user clicks an item (day on month view, month on year view and so on) on the most detailed view available, will be called together with onChange. Returns formatted chosen date (single or range).",
+            control: { type: null },
+        },
         prev2AriaLabel: {
             table: {
                 type: { summary: "string | undefined" },
@@ -391,10 +415,26 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const DefaultDatePicker: Story = {
-    args: {},
-};
+const Template: React.FC<Template> = ({ ...args }: Template) => {
+    const [date, setDate] = useState<Template["value"]>(new Date());
+    const [formattedDate, setFormattedDate] = useState("");
 
-export const DatePickerWithRangeSelection: Story = {
-    args: { selectRange: true },
+    return (
+        <>
+            <Text as="div">Selected date: {formattedDate}</Text>
+            <DatePicker
+                {...args}
+                value={date}
+                onChange={(value) => setDate(value)}
+                onFormattedDate={(value) => setFormattedDate(value)}
+            />
+        </>
+    );
+};
+export const DefaultDatePicker = Template.bind(this) as Story;
+DefaultDatePicker.args = {};
+
+export const DatePickerWithRangeSelection = Template.bind(this) as Story;
+DatePickerWithRangeSelection.args = {
+    selectRange: true,
 };

--- a/lib/components/Atom/Calendar/date-picker.stories.tsx
+++ b/lib/components/Atom/Calendar/date-picker.stories.tsx
@@ -1,6 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 import { Text } from "@components/Typography";
+import {
+    LabelPairedChevronsRightSmFillIcon,
+    LabelPairedChevronsLeftSmFillIcon,
+} from "@deriv/quill-icons";
 import { DatePicker } from "./index";
 
 type Template = React.ComponentProps<typeof DatePicker>;
@@ -437,4 +441,60 @@ DefaultDatePicker.args = {};
 export const DatePickerWithRangeSelection = Template.bind(this) as Story;
 DatePickerWithRangeSelection.args = {
     selectRange: true,
+};
+
+export const DatePickerWithDoubleNavigation = Template.bind(this) as Story;
+DatePickerWithDoubleNavigation.args = {
+    next2Label: (
+        <LabelPairedChevronsRightSmFillIcon fill="var(--component-textIcon-normal-prominent)" />
+    ),
+    prev2Label: (
+        <LabelPairedChevronsLeftSmFillIcon fill="var(--component-textIcon-normal-prominent)" />
+    ),
+};
+
+export const DatePickerWithCustomConfigForFormattingSelectedDate =
+    Template.bind(this) as Story;
+DatePickerWithCustomConfigForFormattingSelectedDate.args = {
+    optionsConfig: {
+        day: "numeric",
+        month: "short",
+        year: "numeric",
+    },
+};
+
+export const DatePickerWithCustomMonthAndYearFormatting = Template.bind(
+    this,
+) as Story;
+DatePickerWithCustomMonthAndYearFormatting.args = {
+    formatMonthYear: (locale, date) =>
+        new Date(date).toLocaleString(locale || navigator.languages, {
+            month: "2-digit",
+            year: "2-digit",
+        }),
+};
+
+export const DatePickerWithoutNavigation = Template.bind(this) as Story;
+DatePickerWithoutNavigation.args = {
+    showNavigation: false,
+};
+
+export const DatePickerWithNeighboringMonth = Template.bind(this) as Story;
+DatePickerWithNeighboringMonth.args = {
+    showNeighboringMonth: true,
+};
+
+export const DatePickerWithCustomActiveStartDate = Template.bind(this) as Story;
+DatePickerWithCustomActiveStartDate.args = {
+    activeStartDate: new Date(2017, 0, 1),
+};
+
+export const DatePickerGregoryType = Template.bind(this) as Story;
+DatePickerGregoryType.args = {
+    calendarType: "gregory",
+};
+
+export const DatePickerIslamicType = Template.bind(this) as Story;
+DatePickerIslamicType.args = {
+    calendarType: "islamic",
 };

--- a/lib/components/Atom/Calendar/date-picker.stories.tsx
+++ b/lib/components/Atom/Calendar/date-picker.stories.tsx
@@ -55,7 +55,7 @@ const meta = {
         showNeighboringMonth: false,
     },
     argTypes: {
-        activeStartDate: {
+        startDate: {
             table: { type: { summary: "Date | undefined" } },
             description:
                 "The beginning of a period that shall be displayed. If you wish to use react-calendar in an uncontrolled way, use defaultActiveStartDate instead. Default value - today. Example values: new Date(2017, 0, 1).",
@@ -561,7 +561,7 @@ DatePickerWithNeighboringMonth.args = {
 export const DatePickerWithCustomActiveStartDate = Template.bind(this) as Story;
 DatePickerWithCustomActiveStartDate.args = {
     ...meta.args,
-    activeStartDate: new Date(2017, 0, 1),
+    startDate: new Date(2017, 0, 1),
 };
 
 export const DatePickerGregoryType = Template.bind(this) as Story;

--- a/lib/components/Atom/Calendar/index.tsx
+++ b/lib/components/Atom/Calendar/index.tsx
@@ -14,7 +14,7 @@ interface DatePicker
         React.ComponentProps<typeof Calendar>,
         "onChange" | "activeStartDate"
     > {
-    isWidthFixed?: boolean;
+    hasFixedWidth?: boolean;
     optionsConfig?: Record<string, string>;
     onChange?: (
         value: Value,
@@ -36,7 +36,7 @@ export const DatePicker = ({
     className,
     defaultValue,
     defaultView,
-    isWidthFixed = true,
+    hasFixedWidth = true,
     formatMonthYear = (locale, date) =>
         new Date(date).toLocaleString(locale || navigator.languages, {
             month: "short",
@@ -92,7 +92,7 @@ export const DatePicker = ({
         <div
             className={clsx(
                 "quill-date-picker__wrapper",
-                { "quill-date-picker__wrapper--fixed-width": isWidthFixed },
+                { "quill-date-picker__wrapper--fixed-width": hasFixedWidth },
                 wrapperClassName,
             )}
         >

--- a/lib/components/Atom/Calendar/index.tsx
+++ b/lib/components/Atom/Calendar/index.tsx
@@ -7,12 +7,11 @@ import {
     LabelPairedChevronRightSmFillIcon,
     LabelPairedChevronLeftSmFillIcon,
 } from "@deriv/quill-icons";
-// import { Text } from "@components/Typography";
+import { Text } from "@components/Typography";
 
-// export interface DatePicker {
-//     activeStartDate?: Date;
-//     className?: string;
-//     calendarType?: "gregory" | "hebrew" | "islamic" | "iso8601";
+// TODO: rewrite interface after adding input
+// export interface DatePicker extends React.ComponentProps<typeof Calendar> {
+//     ...
 // }
 
 type ValuePiece = Date | null;
@@ -30,7 +29,11 @@ export const DatePicker = ({
     formatDay,
     formatLongDate,
     formatMonth,
-    formatMonthYear,
+    formatMonthYear = (locale, date) =>
+        new Date(date).toLocaleString(locale || navigator.languages, {
+            month: "short",
+            year: "numeric",
+        }),
     formatShortWeekday,
     formatWeekday,
     formatYear,
@@ -43,13 +46,13 @@ export const DatePicker = ({
     minDetail = "century",
     navigationAriaLabel,
     navigationAriaLive,
+    navigationLabel = ({ label }) => <Text as="span">{label}</Text>,
 }: React.ComponentProps<typeof Calendar>) => {
     const [date, setDate] = useState<Value>(new Date());
-    // console.log(
-    //     "test  typeof new Date(2017, 0, 1)",
-    //     typeof new Date(2017, 0, 1),
-    //     typeof new Date(),
-    // );
+
+    // TODO: add input with ability to enabling user typing
+    // TODO: add normal wrapper for Calendar
+
     return (
         <div style={{ width: "368px" }}>
             <Calendar
@@ -76,6 +79,7 @@ export const DatePicker = ({
                 minDetail={minDetail}
                 navigationAriaLabel={navigationAriaLabel}
                 navigationAriaLive={navigationAriaLive}
+                navigationLabel={navigationLabel}
                 onChange={setDate}
                 value={date}
                 next2Label={null}

--- a/lib/components/Atom/Calendar/index.tsx
+++ b/lib/components/Atom/Calendar/index.tsx
@@ -68,6 +68,7 @@ export const DatePicker = ({
     selectRange = false,
     showNavigation = true,
     showNeighboringMonth = false,
+    tileClassName,
 }: DatePicker) => {
     const [date, setDate] = useState<Value>(new Date());
 
@@ -131,7 +132,6 @@ export const DatePicker = ({
                     navigationAriaLive={navigationAriaLive}
                     navigationLabel={navigationLabel}
                     next2AriaLabel={next2AriaLabel}
-                    value={date}
                     next2Label={next2Label}
                     nextAriaLabel={nextAriaLabel}
                     nextLabel={nextLabel}
@@ -145,8 +145,8 @@ export const DatePicker = ({
                     selectRange={selectRange}
                     showNavigation={showNavigation}
                     showNeighboringMonth={showNeighboringMonth}
-                    // TODO
-                    tileClassName="test"
+                    tileClassName={tileClassName}
+                    value={date}
                 />
             </div>
         </>

--- a/lib/components/Atom/Calendar/index.tsx
+++ b/lib/components/Atom/Calendar/index.tsx
@@ -67,6 +67,7 @@ export const DatePicker = ({
     returnValue = "start",
     selectRange = false,
     showNavigation = true,
+    showNeighboringMonth = false,
 }: DatePicker) => {
     const [date, setDate] = useState<Value>(new Date());
 
@@ -143,8 +144,9 @@ export const DatePicker = ({
                     returnValue={returnValue}
                     selectRange={selectRange}
                     showNavigation={showNavigation}
-                    // TODO: add all props
-                    showNeighboringMonth={false}
+                    showNeighboringMonth={showNeighboringMonth}
+                    // TODO
+                    tileClassName="test"
                 />
             </div>
         </>

--- a/lib/components/Atom/Calendar/index.tsx
+++ b/lib/components/Atom/Calendar/index.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import clsx from "clsx";
 import Calendar from "react-calendar";
 import "react-calendar/dist/Calendar.css";
@@ -9,8 +8,14 @@ import {
 } from "@deriv/quill-icons";
 import { Text } from "@components/Typography";
 
-export interface DatePicker extends React.ComponentProps<typeof Calendar> {
+interface DatePicker
+    extends Omit<React.ComponentProps<typeof Calendar>, "onChange"> {
     optionsConfig?: Record<string, string>;
+    onChange?: (
+        value: Value,
+        event?: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+    ) => void;
+    onFormattedDate?: (value: string) => void;
 }
 
 type ValuePiece = Date | null;
@@ -22,33 +27,19 @@ export const DatePicker = ({
     allowPartialRange = false,
     calendarType,
     className,
-    defaultActiveStartDate,
     defaultValue,
     defaultView,
-    formatDay,
-    formatLongDate,
-    formatMonth,
     formatMonthYear = (locale, date) =>
         new Date(date).toLocaleString(locale || navigator.languages, {
             month: "short",
             year: "numeric",
         }),
-    formatShortWeekday,
-    formatWeekday,
-    formatYear,
     goToRangeStartOnSelect = true,
-    inputRef,
     locale,
-    maxDate,
     maxDetail = "month",
-    minDate,
     minDetail = "century",
-    navigationAriaLabel,
-    navigationAriaLive,
     navigationLabel = ({ label }) => <Text as="span">{label}</Text>,
-    next2AriaLabel,
     next2Label = null,
-    nextAriaLabel,
     nextLabel = (
         <LabelPairedChevronRightSmFillIcon fill="var(--component-textIcon-normal-prominent)" />
     ),
@@ -57,10 +48,9 @@ export const DatePicker = ({
         month: "2-digit",
         year: "numeric",
     },
-    onActiveStartDateChange,
-    prev2AriaLabel,
+    onChange,
+    onFormattedDate,
     prev2Label = null,
-    prevAriaLabel,
     prevLabel = (
         <LabelPairedChevronLeftSmFillIcon fill="var(--component-textIcon-normal-prominent)" />
     ),
@@ -69,86 +59,56 @@ export const DatePicker = ({
     showNavigation = true,
     showNeighboringMonth = false,
     tileClassName,
+    value,
+    ...rest
 }: DatePicker) => {
-    const [date, setDate] = useState<Value>(new Date());
-
-    const formatLocaleString = (
-        date: Date,
-        config: Record<string, string>,
-        locale?: string | string[],
-    ) => date.toLocaleString(locale, config);
+    const formatLocaleString = (date: Date) =>
+        date.toLocaleString(locale || navigator.language, optionsConfig);
 
     const formatSelectedDate = (date: Value) => {
-        if (!date) return null;
+        if (!date) return "";
         if (Array.isArray(date)) {
             return date
-                .map((item) =>
-                    item
-                        ? formatLocaleString(
-                              item,
-                              optionsConfig,
-                              locale || navigator.language,
-                          )
-                        : "",
-                )
+                .map((item) => (item ? formatLocaleString(item) : ""))
                 .join(" - ");
         }
-        return formatLocaleString(
-            date,
-            optionsConfig,
-            locale || navigator.language,
-        );
+        return formatLocaleString(date);
     };
+
     // TODO: add input with ability to enabling user typing
     // TODO: add normal wrapper for Calendar
 
     return (
-        <>
-            <div>{formatSelectedDate(date)}</div>
-            <div style={{ width: "368px" }}>
-                <Calendar
-                    activeStartDate={activeStartDate}
-                    allowPartialRange={allowPartialRange}
-                    calendarType={calendarType}
-                    className={clsx("quill-date-picker", className)}
-                    defaultActiveStartDate={defaultActiveStartDate}
-                    defaultValue={defaultValue}
-                    defaultView={defaultView}
-                    formatDay={formatDay}
-                    formatLongDate={formatLongDate}
-                    formatMonth={formatMonth}
-                    formatMonthYear={formatMonthYear}
-                    formatShortWeekday={formatShortWeekday}
-                    formatWeekday={formatWeekday}
-                    formatYear={formatYear}
-                    goToRangeStartOnSelect={goToRangeStartOnSelect}
-                    inputRef={inputRef}
-                    locale={locale}
-                    maxDate={maxDate}
-                    maxDetail={maxDetail}
-                    minDate={minDate}
-                    minDetail={minDetail}
-                    navigationAriaLabel={navigationAriaLabel}
-                    navigationAriaLive={navigationAriaLive}
-                    navigationLabel={navigationLabel}
-                    next2AriaLabel={next2AriaLabel}
-                    next2Label={next2Label}
-                    nextAriaLabel={nextAriaLabel}
-                    nextLabel={nextLabel}
-                    onActiveStartDateChange={onActiveStartDateChange}
-                    onChange={(value) => setDate(value)}
-                    prev2AriaLabel={prev2AriaLabel}
-                    prev2Label={prev2Label}
-                    prevAriaLabel={prevAriaLabel}
-                    prevLabel={prevLabel}
-                    returnValue={returnValue}
-                    selectRange={selectRange}
-                    showNavigation={showNavigation}
-                    showNeighboringMonth={showNeighboringMonth}
-                    tileClassName={tileClassName}
-                    value={date}
-                />
-            </div>
-        </>
+        <div style={{ width: "368px" }}>
+            <Calendar
+                {...rest}
+                activeStartDate={activeStartDate}
+                allowPartialRange={allowPartialRange}
+                calendarType={calendarType}
+                className={clsx("quill-date-picker", className)}
+                defaultValue={defaultValue}
+                defaultView={defaultView}
+                formatMonthYear={formatMonthYear}
+                goToRangeStartOnSelect={goToRangeStartOnSelect}
+                locale={locale}
+                maxDetail={maxDetail}
+                minDetail={minDetail}
+                navigationLabel={navigationLabel}
+                next2Label={next2Label}
+                nextLabel={nextLabel}
+                onChange={(value, event) => {
+                    onChange?.(value, event);
+                    onFormattedDate?.(formatSelectedDate(value));
+                }}
+                prev2Label={prev2Label}
+                prevLabel={prevLabel}
+                returnValue={returnValue}
+                selectRange={selectRange}
+                showNavigation={showNavigation}
+                showNeighboringMonth={showNeighboringMonth}
+                tileClassName={tileClassName}
+                value={value}
+            />
+        </div>
     );
 };

--- a/lib/components/Atom/Calendar/index.tsx
+++ b/lib/components/Atom/Calendar/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-// import clsx from "clsx";
+import clsx from "clsx";
 import Calendar from "react-calendar";
 import "react-calendar/dist/Calendar.css";
 import "./date-picker.scss";
@@ -23,23 +23,59 @@ export const DatePicker = ({
     activeStartDate,
     allowPartialRange = false,
     calendarType,
-    className = "quill-checkbox__date-picker",
+    className,
     defaultActiveStartDate,
+    defaultValue,
+    defaultView,
+    formatDay,
+    formatLongDate,
+    formatMonth,
+    formatMonthYear,
+    formatShortWeekday,
+    formatWeekday,
+    formatYear,
+    goToRangeStartOnSelect = true,
+    inputRef,
+    locale,
+    maxDate,
+    maxDetail = "month",
+    minDate,
+    minDetail = "century",
+    navigationAriaLabel,
+    navigationAriaLive,
 }: React.ComponentProps<typeof Calendar>) => {
     const [date, setDate] = useState<Value>(new Date());
-    console.log("test activeStartDate", activeStartDate);
+    // console.log(
+    //     "test  typeof new Date(2017, 0, 1)",
+    //     typeof new Date(2017, 0, 1),
+    //     typeof new Date(),
+    // );
     return (
         <div style={{ width: "368px" }}>
             <Calendar
-                activeStartDate={
-                    typeof activeStartDate === "number"
-                        ? new Date(activeStartDate)
-                        : activeStartDate
-                }
+                activeStartDate={activeStartDate}
                 allowPartialRange={allowPartialRange}
                 calendarType={calendarType}
-                className={className}
+                className={clsx("quill-date-picker", className)}
                 defaultActiveStartDate={defaultActiveStartDate}
+                defaultValue={defaultValue}
+                defaultView={defaultView}
+                formatDay={formatDay}
+                formatLongDate={formatLongDate}
+                formatMonth={formatMonth}
+                formatMonthYear={formatMonthYear}
+                formatShortWeekday={formatShortWeekday}
+                formatWeekday={formatWeekday}
+                formatYear={formatYear}
+                goToRangeStartOnSelect={goToRangeStartOnSelect}
+                inputRef={inputRef}
+                locale={locale}
+                maxDate={maxDate}
+                maxDetail={maxDetail}
+                minDate={minDate}
+                minDetail={minDetail}
+                navigationAriaLabel={navigationAriaLabel}
+                navigationAriaLive={navigationAriaLive}
                 onChange={setDate}
                 value={date}
                 next2Label={null}
@@ -47,7 +83,6 @@ export const DatePicker = ({
                 nextLabel={<LabelPairedChevronRightSmFillIcon />}
                 prevLabel={<LabelPairedChevronLeftSmFillIcon />}
                 showNeighboringMonth={false}
-                // view={"century"}
             />
         </div>
     );

--- a/lib/components/Atom/Calendar/index.tsx
+++ b/lib/components/Atom/Calendar/index.tsx
@@ -9,10 +9,9 @@ import {
 } from "@deriv/quill-icons";
 import { Text } from "@components/Typography";
 
-// TODO: rewrite interface after adding input
-// export interface DatePicker extends React.ComponentProps<typeof Calendar> {
-//     ...
-// }
+export interface DatePicker extends React.ComponentProps<typeof Calendar> {
+    optionsConfig?: Record<string, string>;
+}
 
 type ValuePiece = Date | null;
 
@@ -47,47 +46,101 @@ export const DatePicker = ({
     navigationAriaLabel,
     navigationAriaLive,
     navigationLabel = ({ label }) => <Text as="span">{label}</Text>,
-}: React.ComponentProps<typeof Calendar>) => {
+    next2AriaLabel,
+    next2Label = null,
+    nextAriaLabel,
+    nextLabel = <LabelPairedChevronRightSmFillIcon />,
+    optionsConfig = {
+        day: "2-digit",
+        month: "2-digit",
+        year: "numeric",
+    },
+    onActiveStartDateChange,
+    prev2AriaLabel,
+    prev2Label = null,
+    prevAriaLabel,
+    prevLabel = <LabelPairedChevronLeftSmFillIcon />,
+    returnValue = "start",
+    selectRange = false,
+}: DatePicker) => {
     const [date, setDate] = useState<Value>(new Date());
 
+    const formatLocaleString = (
+        date: Date,
+        config: Record<string, string>,
+        locale?: string | string[],
+    ) => date.toLocaleString(locale, config);
+
+    const formatSelectedDate = (date: Value) => {
+        if (!date) return null;
+        if (Array.isArray(date)) {
+            return date
+                .map((item) =>
+                    item
+                        ? formatLocaleString(
+                              item,
+                              optionsConfig,
+                              locale || navigator.language,
+                          )
+                        : "",
+                )
+                .join(" - ");
+        }
+        return formatLocaleString(
+            date,
+            optionsConfig,
+            locale || navigator.language,
+        );
+    };
     // TODO: add input with ability to enabling user typing
     // TODO: add normal wrapper for Calendar
 
     return (
-        <div style={{ width: "368px" }}>
-            <Calendar
-                activeStartDate={activeStartDate}
-                allowPartialRange={allowPartialRange}
-                calendarType={calendarType}
-                className={clsx("quill-date-picker", className)}
-                defaultActiveStartDate={defaultActiveStartDate}
-                defaultValue={defaultValue}
-                defaultView={defaultView}
-                formatDay={formatDay}
-                formatLongDate={formatLongDate}
-                formatMonth={formatMonth}
-                formatMonthYear={formatMonthYear}
-                formatShortWeekday={formatShortWeekday}
-                formatWeekday={formatWeekday}
-                formatYear={formatYear}
-                goToRangeStartOnSelect={goToRangeStartOnSelect}
-                inputRef={inputRef}
-                locale={locale}
-                maxDate={maxDate}
-                maxDetail={maxDetail}
-                minDate={minDate}
-                minDetail={minDetail}
-                navigationAriaLabel={navigationAriaLabel}
-                navigationAriaLive={navigationAriaLive}
-                navigationLabel={navigationLabel}
-                onChange={setDate}
-                value={date}
-                next2Label={null}
-                prev2Label={null}
-                nextLabel={<LabelPairedChevronRightSmFillIcon />}
-                prevLabel={<LabelPairedChevronLeftSmFillIcon />}
-                showNeighboringMonth={false}
-            />
-        </div>
+        <>
+            <div>{formatSelectedDate(date)}</div>
+            <div style={{ width: "368px" }}>
+                <Calendar
+                    activeStartDate={activeStartDate}
+                    allowPartialRange={allowPartialRange}
+                    calendarType={calendarType}
+                    className={clsx("quill-date-picker", className)}
+                    defaultActiveStartDate={defaultActiveStartDate}
+                    defaultValue={defaultValue}
+                    defaultView={defaultView}
+                    formatDay={formatDay}
+                    formatLongDate={formatLongDate}
+                    formatMonth={formatMonth}
+                    formatMonthYear={formatMonthYear}
+                    formatShortWeekday={formatShortWeekday}
+                    formatWeekday={formatWeekday}
+                    formatYear={formatYear}
+                    goToRangeStartOnSelect={goToRangeStartOnSelect}
+                    inputRef={inputRef}
+                    locale={locale}
+                    maxDate={maxDate}
+                    maxDetail={maxDetail}
+                    minDate={minDate}
+                    minDetail={minDetail}
+                    navigationAriaLabel={navigationAriaLabel}
+                    navigationAriaLive={navigationAriaLive}
+                    navigationLabel={navigationLabel}
+                    next2AriaLabel={next2AriaLabel}
+                    value={date}
+                    next2Label={next2Label}
+                    nextAriaLabel={nextAriaLabel}
+                    nextLabel={nextLabel}
+                    onActiveStartDateChange={onActiveStartDateChange}
+                    onChange={(value) => setDate(value)}
+                    prev2AriaLabel={prev2AriaLabel}
+                    prev2Label={prev2Label}
+                    prevAriaLabel={prevAriaLabel}
+                    prevLabel={prevLabel}
+                    returnValue={returnValue}
+                    selectRange={selectRange}
+                    //la
+                    showNeighboringMonth={false}
+                />
+            </div>
+        </>
     );
 };

--- a/lib/components/Atom/Calendar/index.tsx
+++ b/lib/components/Atom/Calendar/index.tsx
@@ -81,7 +81,7 @@ export const DatePicker = ({
     };
 
     useEffect(() => {
-        onFormattedDate?.(formatSelectedDate((value as Value) || new Date()));
+        if (value) onFormattedDate?.(formatSelectedDate(value as Value));
     }, []);
 
     return (

--- a/lib/components/Atom/Calendar/index.tsx
+++ b/lib/components/Atom/Calendar/index.tsx
@@ -16,6 +16,8 @@ interface DatePicker
         event?: React.MouseEvent<HTMLButtonElement, MouseEvent>,
     ) => void;
     onFormattedDate?: (value: string) => void;
+    isWidthFixed?: boolean;
+    wrapperClassName?: string;
 }
 
 type ValuePiece = Date | null;
@@ -29,6 +31,7 @@ export const DatePicker = ({
     className,
     defaultValue,
     defaultView,
+    isWidthFixed = true,
     formatMonthYear = (locale, date) =>
         new Date(date).toLocaleString(locale || navigator.languages, {
             month: "short",
@@ -60,6 +63,7 @@ export const DatePicker = ({
     showNeighboringMonth = false,
     tileClassName,
     value,
+    wrapperClassName,
     ...rest
 }: DatePicker) => {
     const formatLocaleString = (date: Date) =>
@@ -75,11 +79,14 @@ export const DatePicker = ({
         return formatLocaleString(date);
     };
 
-    // TODO: add input with ability to enabling user typing
-    // TODO: add normal wrapper for Calendar
-
     return (
-        <div style={{ width: "368px" }}>
+        <div
+            className={clsx(
+                "quill-date-picker__wrapper",
+                { "quill-date-picker__wrapper--fixed-width": isWidthFixed },
+                wrapperClassName,
+            )}
+        >
             <Calendar
                 {...rest}
                 activeStartDate={activeStartDate}

--- a/lib/components/Atom/Calendar/index.tsx
+++ b/lib/components/Atom/Calendar/index.tsx
@@ -10,14 +10,18 @@ import {
 import { Text } from "@components/Typography";
 
 interface DatePicker
-    extends Omit<React.ComponentProps<typeof Calendar>, "onChange"> {
+    extends Omit<
+        React.ComponentProps<typeof Calendar>,
+        "onChange" | "activeStartDate"
+    > {
+    isWidthFixed?: boolean;
     optionsConfig?: Record<string, string>;
     onChange?: (
         value: Value,
         event?: React.MouseEvent<HTMLButtonElement, MouseEvent>,
     ) => void;
     onFormattedDate?: (value: string) => void;
-    isWidthFixed?: boolean;
+    startDate?: Date;
     wrapperClassName?: string;
 }
 
@@ -26,7 +30,7 @@ type ValuePiece = Date | null;
 type Value = ValuePiece | [ValuePiece, ValuePiece];
 
 export const DatePicker = ({
-    activeStartDate,
+    startDate,
     allowPartialRange = false,
     calendarType,
     className,
@@ -94,7 +98,7 @@ export const DatePicker = ({
         >
             <Calendar
                 {...rest}
-                activeStartDate={activeStartDate}
+                activeStartDate={startDate}
                 allowPartialRange={allowPartialRange}
                 calendarType={calendarType}
                 className={clsx("quill-date-picker", className)}

--- a/lib/components/Atom/Calendar/index.tsx
+++ b/lib/components/Atom/Calendar/index.tsx
@@ -49,7 +49,9 @@ export const DatePicker = ({
     next2AriaLabel,
     next2Label = null,
     nextAriaLabel,
-    nextLabel = <LabelPairedChevronRightSmFillIcon />,
+    nextLabel = (
+        <LabelPairedChevronRightSmFillIcon fill="var(--component-textIcon-normal-prominent)" />
+    ),
     optionsConfig = {
         day: "2-digit",
         month: "2-digit",
@@ -59,9 +61,12 @@ export const DatePicker = ({
     prev2AriaLabel,
     prev2Label = null,
     prevAriaLabel,
-    prevLabel = <LabelPairedChevronLeftSmFillIcon />,
+    prevLabel = (
+        <LabelPairedChevronLeftSmFillIcon fill="var(--component-textIcon-normal-prominent)" />
+    ),
     returnValue = "start",
     selectRange = false,
+    showNavigation = true,
 }: DatePicker) => {
     const [date, setDate] = useState<Value>(new Date());
 
@@ -137,7 +142,8 @@ export const DatePicker = ({
                     prevLabel={prevLabel}
                     returnValue={returnValue}
                     selectRange={selectRange}
-                    //la
+                    showNavigation={showNavigation}
+                    // TODO: add all props
                     showNeighboringMonth={false}
                 />
             </div>

--- a/lib/components/Atom/Calendar/index.tsx
+++ b/lib/components/Atom/Calendar/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import clsx from "clsx";
 import Calendar from "react-calendar";
 import "react-calendar/dist/Calendar.css";
@@ -78,6 +79,10 @@ export const DatePicker = ({
         }
         return formatLocaleString(date);
     };
+
+    useEffect(() => {
+        onFormattedDate?.(formatSelectedDate((value as Value) || new Date()));
+    }, []);
 
     return (
         <div

--- a/lib/components/Atom/Calendar/index.tsx
+++ b/lib/components/Atom/Calendar/index.tsx
@@ -1,0 +1,50 @@
+import { useState } from "react";
+// import clsx from "clsx";
+import Calendar from "react-calendar";
+import "react-calendar/dist/Calendar.css";
+// import { Text } from "@components/Typography";
+
+// export interface DatePicker {
+//     activeStartDate?: Date;
+//     className?: string;
+//     calendarType?: "gregory" | "hebrew" | "islamic" | "iso8601";
+// }
+
+type ValuePiece = Date | null;
+
+type Value = ValuePiece | [ValuePiece, ValuePiece];
+
+export const DatePicker = ({
+    activeStartDate,
+    allowPartialRange = false,
+    calendarType,
+    className,
+    defaultActiveStartDate,
+}: React.ComponentProps<typeof Calendar>) => {
+    const [date, setDate] = useState<Value>(new Date());
+    console.log("test activeStartDate", activeStartDate);
+    return (
+        <div>
+            <Calendar
+                activeStartDate={
+                    typeof activeStartDate === "number"
+                        ? new Date(activeStartDate)
+                        : activeStartDate
+                }
+                allowPartialRange={allowPartialRange}
+                calendarType={calendarType}
+                className={className}
+                defaultActiveStartDate={defaultActiveStartDate}
+                onChange={setDate}
+                value={date}
+            />
+            <button
+                onClick={() => {
+                    setDate(new Date());
+                }}
+            >
+                Set current Date
+            </button>
+        </div>
+    );
+};

--- a/lib/components/Atom/Calendar/index.tsx
+++ b/lib/components/Atom/Calendar/index.tsx
@@ -2,6 +2,11 @@ import { useState } from "react";
 // import clsx from "clsx";
 import Calendar from "react-calendar";
 import "react-calendar/dist/Calendar.css";
+import "./date-picker.scss";
+import {
+    LabelPairedChevronRightSmFillIcon,
+    LabelPairedChevronLeftSmFillIcon,
+} from "@deriv/quill-icons";
 // import { Text } from "@components/Typography";
 
 // export interface DatePicker {
@@ -18,13 +23,13 @@ export const DatePicker = ({
     activeStartDate,
     allowPartialRange = false,
     calendarType,
-    className,
+    className = "quill-checkbox__date-picker",
     defaultActiveStartDate,
 }: React.ComponentProps<typeof Calendar>) => {
     const [date, setDate] = useState<Value>(new Date());
     console.log("test activeStartDate", activeStartDate);
     return (
-        <div>
+        <div style={{ width: "368px" }}>
             <Calendar
                 activeStartDate={
                     typeof activeStartDate === "number"
@@ -37,14 +42,13 @@ export const DatePicker = ({
                 defaultActiveStartDate={defaultActiveStartDate}
                 onChange={setDate}
                 value={date}
+                next2Label={null}
+                prev2Label={null}
+                nextLabel={<LabelPairedChevronRightSmFillIcon />}
+                prevLabel={<LabelPairedChevronLeftSmFillIcon />}
+                showNeighboringMonth={false}
+                // view={"century"}
             />
-            <button
-                onClick={() => {
-                    setDate(new Date());
-                }}
-            >
-                Set current Date
-            </button>
         </div>
     );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "dependencies": {
                 "@deriv/quill-icons": "^1.19.20",
                 "@headlessui/react": "^1.7.18",
+                "react-calendar": "^5.0.0",
                 "react-swipeable": "^6.2.1",
                 "usehooks-ts": "^3.0.2",
                 "uuid": "^9.0.1"
@@ -8072,7 +8073,7 @@
             "version": "15.7.11",
             "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
             "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/@types/qs": {
             "version": "6.9.14",
@@ -8090,7 +8091,7 @@
             "version": "18.2.66",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.66.tgz",
             "integrity": "sha512-OYTmMI4UigXeFMF/j4uv0lBBEbongSgptPrHBxqME44h9+yNov+oL6Z3ocJKo0WyXR84sQUNeyIp9MRfckvZpg==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "@types/scheduler": "*",
@@ -8116,7 +8117,7 @@
             "version": "0.16.8",
             "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
             "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/@types/semver": {
             "version": "7.5.8",
@@ -8927,6 +8928,14 @@
             "dependencies": {
                 "@webassemblyjs/ast": "1.12.1",
                 "@xtuc/long": "4.2.2"
+            }
+        },
+        "node_modules/@wojtekmaj/date-utils": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/@wojtekmaj/date-utils/-/date-utils-1.5.1.tgz",
+            "integrity": "sha512-+i7+JmNiE/3c9FKxzWFi2IjRJ+KzZl1QPu6QNrsgaa2MuBgXvUy4gA1TVzf/JMdIIloB76xSKikTWuyYAIVLww==",
+            "funding": {
+                "url": "https://github.com/wojtekmaj/date-utils?sponsor=1"
             }
         },
         "node_modules/@xtuc/ieee754": {
@@ -10458,7 +10467,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
             "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
-            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -11039,7 +11047,7 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
             "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-            "dev": true
+            "devOptional": true
         },
         "node_modules/dargs": {
             "version": "8.1.0",
@@ -13309,6 +13317,17 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/get-user-locale": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/get-user-locale/-/get-user-locale-2.3.2.tgz",
+            "integrity": "sha512-O2GWvQkhnbDoWFUJfaBlDIKUEdND8ATpBXD6KXcbhxlfktyD/d8w6mkzM/IlQEqGZAMz/PW6j6Hv53BiigKLUQ==",
+            "dependencies": {
+                "mem": "^8.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/wojtekmaj/get-user-locale?sponsor=1"
             }
         },
         "node_modules/giget": {
@@ -17817,6 +17836,17 @@
                 "tmpl": "1.0.5"
             }
         },
+        "node_modules/map-age-cleaner": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+            "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+            "dependencies": {
+                "p-defer": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/map-or-similar": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/map-or-similar/-/map-or-similar-1.5.0.tgz",
@@ -17919,6 +17949,29 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/mem": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/mem/-/mem-8.1.1.tgz",
+            "integrity": "sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==",
+            "dependencies": {
+                "map-age-cleaner": "^0.1.3",
+                "mimic-fn": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/mem?sponsor=1"
+            }
+        },
+        "node_modules/mem/node_modules/mimic-fn": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
+            "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/memoizerific": {
@@ -21420,6 +21473,14 @@
                 "node": ">=8"
             }
         },
+        "node_modules/p-defer": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+            "integrity": "sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==",
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/p-each-series": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-3.0.0.tgz",
@@ -22284,6 +22345,30 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/react-calendar": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/react-calendar/-/react-calendar-5.0.0.tgz",
+            "integrity": "sha512-bHcE5e5f+VUKLd4R19BGkcSQLpuwjKBVG0fKz74cwPW5xDfNsReHdDbfd4z3mdjuUuZzVtw4Q920mkwK5/ZOEg==",
+            "dependencies": {
+                "@wojtekmaj/date-utils": "^1.1.3",
+                "clsx": "^2.0.0",
+                "get-user-locale": "^2.2.1",
+                "warning": "^4.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/wojtekmaj/react-calendar?sponsor=1"
+            },
+            "peerDependencies": {
+                "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/react-colorful": {
             "version": "5.6.1",
             "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
@@ -22385,12 +22470,6 @@
             "peerDependencies": {
                 "react": "^16.8.3 || ^17 || ^18"
             }
-        },
-        "node_modules/react-uuid": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/react-uuid/-/react-uuid-2.0.0.tgz",
-            "integrity": "sha512-FNUH/8WR/FEtx0Bu6gmt1eONfc413hhvrEXFWUSFGvznUhI4dYoVZA09p7JHoTpnM4WC2D/bG2YSxGKXF4oVLg==",
-            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info."
         },
         "node_modules/read-pkg": {
             "version": "9.0.1",
@@ -25905,6 +25984,14 @@
             "dev": true,
             "dependencies": {
                 "makeerror": "1.0.12"
+            }
+        },
+        "node_modules/warning": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+            "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+            "dependencies": {
+                "loose-envify": "^1.0.0"
             }
         },
         "node_modules/watchpack": {

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "dependencies": {
         "@deriv/quill-icons": "^1.19.20",
         "@headlessui/react": "^1.7.18",
+        "react-calendar": "^5.0.0",
         "react-swipeable": "^6.2.1",
         "usehooks-ts": "^3.0.2",
         "uuid": "^9.0.1"


### PR DESCRIPTION
Created reusable atom component called DatePicker based on the React Calendar library.

        activeStartDate: 
                "The beginning of a period that shall be displayed. If you wish to use react-calendar in an uncontrolled way, use defaultActiveStartDate instead. Default value - today. Example values: new Date(2017, 0, 1).",

        allowPartialRange: 
                "Whether to call onChange with only partial result given selectRange prop. Default value - false.",

        calendarType: 
                "Type of calendar that should be used. Can be 'gregory', 'hebrew', 'islamic', 'iso8601'. Setting to 'gregory' or 'hebrew' will change the first day of the week to Sunday. Setting to 'islamic' will change the first day of the week to Saturday. Setting to 'islamic' or 'hebrew' will make weekends appear on Friday to Saturday. Default value - type of calendar most commonly used in a given locale.",

        className: 
                "Class name(s) that will be added along with 'react-calendar' to the main react-calendar <div> element.",

        defaultActiveStartDate:
        "The beginning of a period that shall be displayed by default. If you wish to use react-calendar in a controlled way, use activeStartDate instead. Default value - today. Example values: new Date(2017, 0, 1).",

        defaultValue: 
                "Calendar value that shall be selected initially. Can be either one value or an array of two values. If you wish to use react-calendar in a controlled way, use value instead. Example values: new Date(2017, 0, 1) or [new Date(2017, 0, 1), new Date(2017, 7, 1)].",

        defaultView: 
                "Determines which calendar view shall be opened initially. Does not disable navigation. Can be 'month', 'year', 'decade' or 'century'. If you wish to use react-calendar in a controlled way, use view instead. Default value - The most detailed view allowed.",

        isWidthFixed: 
                "Determines if width should be fixed or equal to container width. Default value - true",

        formatDay: 
                "Function called to override default formatting of day tile labels. Can be used to use your own formatting function. Default formatter is used if nothing was passed. Example: (locale, date) => formatDate(date, 'd')",

        formatLongDate: 
                "Function called to override default formatting of day tile abbr labels. Can be used to use your own formatting function. Default formatter is used if nothing was passed. Example: (locale, date) => formatDate(date, 'dd MMM YYYY')",

        formatMonth: 
                "Function called to override default formatting of month names. Can be used to use your own formatting function. Default formatter is used if nothing was passed. Example: (locale, date) => formatDate(date, 'MMM')",

        formatMonthYear: 
                "Function called to override default formatting of months and years. Can be used to use your own formatting function. Default formatter: (locale, date) => new Date(date).toLocaleString(locale || navigator.languages, { month: 'short', year: 'numeric' })`. Example: (locale, date) => formatDate(date, 'MMMM YYYY')",

        formatShortWeekday:
                "Function called to override default formatting of weekday names (shortened). Can be used to use your own formatting function. Default formatter is used if nothing was passed. Example: (locale, date) => formatDate(date, 'dd')",

        formatWeekday: 
                "Function called to override default formatting of weekday names. Can be used to use your own formatting function. Default formatter is used if nothing was passed. Example: (locale, date) => formatDate(date, 'dd')",

        formatYear: 
                "Function called to override default formatting of year in the top navigation section. Can be used to use your own formatting function. Default formatter is used if nothing was passed. Example: (locale, date) => formatDate(date, 'YYYY')",

        goToRangeStartOnSelect: 
                "Whether to go to the beginning of the range when selecting the end of the range. Default value - true.",
 
        inputRef: 
                "A prop that behaves like ref, but it's passed to main 'div' rendered by 'Calendar' component.",

        locale: 
                "Locale that should be used by the calendar. Can be any IETF language tag. Note: When using SSR, setting this prop may help resolving hydration errors caused by locale mismatch between server and client. Default value: server locale/User's browser settings. Example: 'hu-HU'.",

        maxDate: 
                "Maximum date that the user can select. Periods partially overlapped by maxDate will also be selectable, although react-calendar will ensure that no later date is selected. Example values: new Date().",

        maxDetail: 
                "The most detailed view that the user shall see. View defined here also becomes the one on which clicking an item will select a date and pass it to onChange. Can be 'month', 'year', 'decade' or 'century'. Default value - 'month'.",

        minDate: 
        "Minimum date that the user can select. Periods partially overlapped by minDate will also be selectable, although react-calendar will ensure that no earlier date is selected. Example values: new Date().",

        minDetail: 
                "The least detailed view that the user shall see. Default value - 'century'.",

        navigationAriaLabel: 
                "aria-label attribute of a label rendered on calendar navigation bar. Example: 'Go up'.",

        navigationAriaLive: 
                "aria-live attribute of a label rendered on calendar navigation bar. Example: 'polite'.",

        navigationLabel: 
                "Content of a label rendered on calendar navigation bar.",

        next2AriaLabel: 
                "aria-label attribute of the 'next on higher level' button on the navigation pane. Example: 'Jump forwards'",

        next2Label: 
                "Content of the 'next on higher level' button on the navigation pane. Setting the value explicitly to null will hide the icon. Default value: null. Example: String: '»'",

        nextAriaLabel: 
                "aria-label attribute of the 'next' button on the navigation pane. Example: 'Next'",

        nextLabel: 
                "Content of the 'next' button on the navigation pane. Setting the value explicitly to null will hide the icon. Default value: LabelPairedChevronRightSmFillIcon. Example: String: '>'",

        optionsConfig: 
                "Config for changing format of the selected date, will be passed inside of Date.toLocaleDateString(). Default value: {day: '2-digit', month: '2-digit', year: 'numeric'}",

        onActiveStartDateChange: 
                "Function called when the user navigates from one view to another using previous/next button. Note that this function will not be called when e.g. drilling up from January 2021 to 2021 or drilling down the other way around. action signifies the reason for active start date change and can be one of the following values: 'prev', 'prev2', 'next', 'next2', 'drillUp', 'drillDown', 'onChange'. Example: ({ action, activeStartDate, value, view }) => alert('Changed view to: ', activeStartDate, view)",

        onChange: 
                "Function called when the user clicks an item (day on month view, month on year view and so on) on the most detailed view available.",

        onFormattedDate: 
                "Function called when the user clicks an item (day on month view, month on year view and so on) on the most detailed view available, will be called together with onChange. Returns formatted chosen date (single or range).",

        prev2AriaLabel: 
                "aria-label attribute of the 'previous on higher level' button on the navigation pane. Example: 'Jump backwards'",

        prev2Label: 
                "Content of the 'previous on higher level' button on the navigation pane. Setting the value explicitly to null will hide the icon. Default value: null. Example: String: '«'",

        prevAriaLabel: 
                "aria-label attribute of the 'previous' button on the navigation pane. Example: 'Previous'",

        prevLabel: 
                "Content of the 'previous' button on the navigation pane. Setting the value explicitly to null will hide the icon. Default value: LabelPairedChevronLeftSmFillIcon. Example: String: '<'",

        returnValue: 
                "Which dates shall be passed by the calendar to the onChange function and onClick{Period} functions. Can be 'start', 'end' or 'range'. The latter will cause an array with start and end values to be passed. Default value: 'start'.",

        selectRange:
                "Whether the user shall select two dates forming a range instead of just one. Note: This feature will make react-calendar return array with two dates regardless of returnValue setting. Default value: false.",

        showNavigation: 
                "Whether a navigation bar with arrows and title shall be rendered. Default value: true.",

        showNeighboringMonth: 
                "Whether days from previous or next month shall be rendered if the month doesn't start on the first day of the week or doesn't end on the last day of the week, respectively. Default value: false.",

        tileClassName:
                "Class name(s) that will be applied to a given calendar item (day on month view, month on year view and so on).",

        value: 
                "Calendar value. Can be either one value or an array of two values. If you wish to use react-calendar in an uncontrolled way, use defaultValue instead.",

        wrapperClassName: 
        "Class that will be applied to a calendar wrapper",


![Screenshot 2024-05-10 at 11 25 27 AM](https://github.com/deriv-com/quill-ui/assets/121025168/b312ca47-a2e2-4ab3-908e-10bc868a0b59)
![Screenshot 2024-05-10 at 11 25 18 AM](https://github.com/deriv-com/quill-ui/assets/121025168/6b6426d1-786f-486f-9f68-f52a7703fc0b)
