### PR TITLE
DTRA / Kate / Add new prop for checkbox position

### DIFF
--- a/lib/components/Atom/Calendar/__tests__/__snapshots__/date-picker.test.tsx.snap
+++ b/lib/components/Atom/Calendar/__tests__/__snapshots__/date-picker.test.tsx.snap
@@ -161,7 +161,7 @@ exports[`DatePicker should render calendar with double navigation if next2Label 
                   </abbr>
                 </div>
                 <div
-                  class="react-calendar__month-view__weekdays__weekday react-calendar__month-view__weekdays__weekday--current"
+                  class="react-calendar__month-view__weekdays__weekday"
                   style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
                 >
                   <abbr
@@ -172,7 +172,7 @@ exports[`DatePicker should render calendar with double navigation if next2Label 
                   </abbr>
                 </div>
                 <div
-                  class="react-calendar__month-view__weekdays__weekday react-calendar__month-view__weekdays__weekday--weekend"
+                  class="react-calendar__month-view__weekdays__weekday react-calendar__month-view__weekdays__weekday--current react-calendar__month-view__weekdays__weekday--weekend"
                   style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
                 >
                   <abbr
@@ -375,7 +375,7 @@ exports[`DatePicker should render calendar with double navigation if next2Label 
                   </abbr>
                 </button>
                 <button
-                  class="react-calendar__tile react-calendar__tile--now react-calendar__month-view__days__day"
+                  class="react-calendar__tile react-calendar__month-view__days__day"
                   style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
                   type="button"
                 >
@@ -386,7 +386,7 @@ exports[`DatePicker should render calendar with double navigation if next2Label 
                   </abbr>
                 </button>
                 <button
-                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  class="react-calendar__tile react-calendar__tile--now react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
                   style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
                   type="button"
                 >
@@ -696,7 +696,7 @@ exports[`DatePicker should render calendar with neighboring month if showNeighbo
                   </abbr>
                 </div>
                 <div
-                  class="react-calendar__month-view__weekdays__weekday react-calendar__month-view__weekdays__weekday--current"
+                  class="react-calendar__month-view__weekdays__weekday"
                   style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
                 >
                   <abbr
@@ -707,7 +707,7 @@ exports[`DatePicker should render calendar with neighboring month if showNeighbo
                   </abbr>
                 </div>
                 <div
-                  class="react-calendar__month-view__weekdays__weekday react-calendar__month-view__weekdays__weekday--weekend"
+                  class="react-calendar__month-view__weekdays__weekday react-calendar__month-view__weekdays__weekday--current react-calendar__month-view__weekdays__weekday--weekend"
                   style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
                 >
                   <abbr
@@ -932,7 +932,7 @@ exports[`DatePicker should render calendar with neighboring month if showNeighbo
                   </abbr>
                 </button>
                 <button
-                  class="react-calendar__tile react-calendar__tile--now react-calendar__month-view__days__day"
+                  class="react-calendar__tile react-calendar__month-view__days__day"
                   style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
                   type="button"
                 >
@@ -943,7 +943,7 @@ exports[`DatePicker should render calendar with neighboring month if showNeighbo
                   </abbr>
                 </button>
                 <button
-                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  class="react-calendar__tile react-calendar__tile--now react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
                   style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
                   type="button"
                 >
@@ -1275,7 +1275,7 @@ exports[`DatePicker should render calendar with range selection 1`] = `
                   </abbr>
                 </div>
                 <div
-                  class="react-calendar__month-view__weekdays__weekday react-calendar__month-view__weekdays__weekday--current"
+                  class="react-calendar__month-view__weekdays__weekday"
                   style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
                 >
                   <abbr
@@ -1286,7 +1286,7 @@ exports[`DatePicker should render calendar with range selection 1`] = `
                   </abbr>
                 </div>
                 <div
-                  class="react-calendar__month-view__weekdays__weekday react-calendar__month-view__weekdays__weekday--weekend"
+                  class="react-calendar__month-view__weekdays__weekday react-calendar__month-view__weekdays__weekday--current react-calendar__month-view__weekdays__weekday--weekend"
                   style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
                 >
                   <abbr
@@ -1489,7 +1489,7 @@ exports[`DatePicker should render calendar with range selection 1`] = `
                   </abbr>
                 </button>
                 <button
-                  class="react-calendar__tile react-calendar__tile--now react-calendar__month-view__days__day"
+                  class="react-calendar__tile react-calendar__month-view__days__day"
                   style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
                   type="button"
                 >
@@ -1500,7 +1500,7 @@ exports[`DatePicker should render calendar with range selection 1`] = `
                   </abbr>
                 </button>
                 <button
-                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  class="react-calendar__tile react-calendar__tile--now react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
                   style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
                   type="button"
                 >
@@ -1810,7 +1810,7 @@ exports[`DatePicker should render calendar with selected value and call onFormat
                   </abbr>
                 </div>
                 <div
-                  class="react-calendar__month-view__weekdays__weekday react-calendar__month-view__weekdays__weekday--current"
+                  class="react-calendar__month-view__weekdays__weekday"
                   style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
                 >
                   <abbr
@@ -1821,7 +1821,7 @@ exports[`DatePicker should render calendar with selected value and call onFormat
                   </abbr>
                 </div>
                 <div
-                  class="react-calendar__month-view__weekdays__weekday react-calendar__month-view__weekdays__weekday--weekend"
+                  class="react-calendar__month-view__weekdays__weekday react-calendar__month-view__weekdays__weekday--current react-calendar__month-view__weekdays__weekday--weekend"
                   style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
                 >
                   <abbr
@@ -2024,7 +2024,7 @@ exports[`DatePicker should render calendar with selected value and call onFormat
                   </abbr>
                 </button>
                 <button
-                  class="react-calendar__tile react-calendar__tile--now react-calendar__tile--active react-calendar__tile--range react-calendar__tile--rangeStart react-calendar__tile--rangeEnd react-calendar__tile--rangeBothEnds react-calendar__month-view__days__day"
+                  class="react-calendar__tile react-calendar__month-view__days__day"
                   style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
                   type="button"
                 >
@@ -2035,7 +2035,7 @@ exports[`DatePicker should render calendar with selected value and call onFormat
                   </abbr>
                 </button>
                 <button
-                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  class="react-calendar__tile react-calendar__tile--now react-calendar__tile--active react-calendar__tile--range react-calendar__tile--rangeStart react-calendar__tile--rangeEnd react-calendar__tile--rangeBothEnds react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
                   style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
                   type="button"
                 >
@@ -2267,7 +2267,7 @@ exports[`DatePicker should render calendar without navigation if showNavigation 
                   </abbr>
                 </div>
                 <div
-                  class="react-calendar__month-view__weekdays__weekday react-calendar__month-view__weekdays__weekday--current"
+                  class="react-calendar__month-view__weekdays__weekday"
                   style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
                 >
                   <abbr
@@ -2278,7 +2278,7 @@ exports[`DatePicker should render calendar without navigation if showNavigation 
                   </abbr>
                 </div>
                 <div
-                  class="react-calendar__month-view__weekdays__weekday react-calendar__month-view__weekdays__weekday--weekend"
+                  class="react-calendar__month-view__weekdays__weekday react-calendar__month-view__weekdays__weekday--current react-calendar__month-view__weekdays__weekday--weekend"
                   style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
                 >
                   <abbr
@@ -2481,7 +2481,7 @@ exports[`DatePicker should render calendar without navigation if showNavigation 
                   </abbr>
                 </button>
                 <button
-                  class="react-calendar__tile react-calendar__tile--now react-calendar__month-view__days__day"
+                  class="react-calendar__tile react-calendar__month-view__days__day"
                   style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
                   type="button"
                 >
@@ -2492,7 +2492,7 @@ exports[`DatePicker should render calendar without navigation if showNavigation 
                   </abbr>
                 </button>
                 <button
-                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  class="react-calendar__tile react-calendar__tile--now react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
                   style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
                   type="button"
                 >
@@ -2802,7 +2802,7 @@ exports[`DatePicker should render with default values if optional ones were not 
                   </abbr>
                 </div>
                 <div
-                  class="react-calendar__month-view__weekdays__weekday react-calendar__month-view__weekdays__weekday--current"
+                  class="react-calendar__month-view__weekdays__weekday"
                   style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
                 >
                   <abbr
@@ -2813,7 +2813,7 @@ exports[`DatePicker should render with default values if optional ones were not 
                   </abbr>
                 </div>
                 <div
-                  class="react-calendar__month-view__weekdays__weekday react-calendar__month-view__weekdays__weekday--weekend"
+                  class="react-calendar__month-view__weekdays__weekday react-calendar__month-view__weekdays__weekday--current react-calendar__month-view__weekdays__weekday--weekend"
                   style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
                 >
                   <abbr
@@ -3016,7 +3016,7 @@ exports[`DatePicker should render with default values if optional ones were not 
                   </abbr>
                 </button>
                 <button
-                  class="react-calendar__tile react-calendar__tile--now react-calendar__month-view__days__day"
+                  class="react-calendar__tile react-calendar__month-view__days__day"
                   style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
                   type="button"
                 >
@@ -3027,7 +3027,7 @@ exports[`DatePicker should render with default values if optional ones were not 
                   </abbr>
                 </button>
                 <button
-                  class="react-calendar__tile react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
+                  class="react-calendar__tile react-calendar__tile--now react-calendar__month-view__days__day react-calendar__month-view__days__day--weekend"
                   style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
                   type="button"
                 >

--- a/lib/components/SelectionControl/checkbox/checkbox-group/__tests__/__snapshots__/checkbox-group.test.tsx.snap
+++ b/lib/components/SelectionControl/checkbox/checkbox-group/__tests__/__snapshots__/checkbox-group.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`CheckboxGroup should render checkbox components according to passed con
         class="quill-checkbox"
       >
         <div
-          class="quill-checkbox__wrapper"
+          class="quill-checkbox__wrapper quill-checkbox__wrapper--left"
         >
           <input
             class="quill-checkbox__box"
@@ -70,7 +70,7 @@ exports[`CheckboxGroup should render checkbox components according to passed con
           class="quill-checkbox"
         >
           <div
-            class="quill-checkbox__wrapper"
+            class="quill-checkbox__wrapper quill-checkbox__wrapper--left"
           >
             <input
               checked=""
@@ -105,7 +105,7 @@ exports[`CheckboxGroup should render checkbox components according to passed con
           class="quill-checkbox"
         >
           <div
-            class="quill-checkbox__wrapper"
+            class="quill-checkbox__wrapper quill-checkbox__wrapper--left"
           >
             <input
               class="quill-checkbox__box"
@@ -139,7 +139,7 @@ exports[`CheckboxGroup should render checkbox components according to passed con
           class="quill-checkbox"
         >
           <div
-            class="quill-checkbox__wrapper"
+            class="quill-checkbox__wrapper quill-checkbox__wrapper--left"
           >
             <input
               class="quill-checkbox__box"
@@ -176,7 +176,7 @@ exports[`CheckboxGroup should render checkbox components according to passed con
         class="quill-checkbox"
       >
         <div
-          class="quill-checkbox__wrapper"
+          class="quill-checkbox__wrapper quill-checkbox__wrapper--left"
         >
           <input
             class="quill-checkbox__box"
@@ -213,7 +213,7 @@ exports[`CheckboxGroup should render checkbox components according to passed con
           class="quill-checkbox"
         >
           <div
-            class="quill-checkbox__wrapper"
+            class="quill-checkbox__wrapper quill-checkbox__wrapper--left"
           >
             <input
               class="quill-checkbox__box"
@@ -250,7 +250,7 @@ exports[`CheckboxGroup should render checkbox components according to passed con
         class="quill-checkbox"
       >
         <div
-          class="quill-checkbox__wrapper"
+          class="quill-checkbox__wrapper quill-checkbox__wrapper--left"
         >
           <input
             checked=""
@@ -310,7 +310,7 @@ exports[`CheckboxGroup should render checkbox components according to passed con
         class="quill-checkbox quill-checkbox--disabled"
       >
         <div
-          class="quill-checkbox__wrapper"
+          class="quill-checkbox__wrapper quill-checkbox__wrapper--left"
         >
           <input
             class="quill-checkbox__box"
@@ -348,7 +348,7 @@ exports[`CheckboxGroup should render checkbox components according to passed con
           class="quill-checkbox quill-checkbox--disabled"
         >
           <div
-            class="quill-checkbox__wrapper"
+            class="quill-checkbox__wrapper quill-checkbox__wrapper--left"
           >
             <input
               class="quill-checkbox__box"
@@ -406,7 +406,7 @@ exports[`CheckboxGroup should render checkbox components according to passed con
           class="quill-checkbox quill-checkbox--disabled"
         >
           <div
-            class="quill-checkbox__wrapper"
+            class="quill-checkbox__wrapper quill-checkbox__wrapper--left"
           >
             <input
               class="quill-checkbox__box"

--- a/lib/components/SelectionControl/checkbox/checkbox-single/__tests__/__snapshots__/checkbox.test.tsx.snap
+++ b/lib/components/SelectionControl/checkbox/checkbox-single/__tests__/__snapshots__/checkbox.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Checkbox should apply className if it was passed 1`] = `
     class="quill-checkbox wrapper_className"
   >
     <div
-      class="quill-checkbox__wrapper"
+      class="quill-checkbox__wrapper quill-checkbox__wrapper--left"
     >
       <input
         class="quill-checkbox__box"
@@ -42,7 +42,7 @@ exports[`Checkbox should apply id if it was passed 1`] = `
     class="quill-checkbox"
   >
     <div
-      class="quill-checkbox__wrapper"
+      class="quill-checkbox__wrapper quill-checkbox__wrapper--left"
     >
       <input
         class="quill-checkbox__box"
@@ -81,7 +81,7 @@ exports[`Checkbox should apply labelClassName if it was passed 1`] = `
     class="quill-checkbox"
   >
     <div
-      class="quill-checkbox__wrapper"
+      class="quill-checkbox__wrapper quill-checkbox__wrapper--left"
     >
       <input
         class="quill-checkbox__box"
@@ -117,7 +117,7 @@ exports[`Checkbox should apply name if it was passed 1`] = `
     class="quill-checkbox"
   >
     <div
-      class="quill-checkbox__wrapper"
+      class="quill-checkbox__wrapper quill-checkbox__wrapper--left"
     >
       <input
         class="quill-checkbox__box"
@@ -157,7 +157,7 @@ exports[`Checkbox should render correct attribute of input if checked === true 1
     class="quill-checkbox"
   >
     <div
-      class="quill-checkbox__wrapper"
+      class="quill-checkbox__wrapper quill-checkbox__wrapper--left"
     >
       <input
         checked=""
@@ -194,7 +194,7 @@ exports[`Checkbox should render correct attribute of input if disabled === true 
     class="quill-checkbox quill-checkbox--disabled"
   >
     <div
-      class="quill-checkbox__wrapper"
+      class="quill-checkbox__wrapper quill-checkbox__wrapper--left"
     >
       <input
         class="quill-checkbox__box"
@@ -231,7 +231,7 @@ exports[`Checkbox should render correct icon if indeterminate === true 1`] = `
     class="quill-checkbox"
   >
     <div
-      class="quill-checkbox__wrapper"
+      class="quill-checkbox__wrapper quill-checkbox__wrapper--left"
     >
       <input
         class="quill-checkbox__box"
@@ -267,7 +267,7 @@ exports[`Checkbox should render correct label size if size === 'md' 1`] = `
     class="quill-checkbox"
   >
     <div
-      class="quill-checkbox__wrapper"
+      class="quill-checkbox__wrapper quill-checkbox__wrapper--left"
     >
       <input
         class="quill-checkbox__box"
@@ -303,7 +303,7 @@ exports[`Checkbox should render info icon if showInfoIcon === true 1`] = `
     class="quill-checkbox"
   >
     <div
-      class="quill-checkbox__wrapper"
+      class="quill-checkbox__wrapper quill-checkbox__wrapper--left"
     >
       <input
         class="quill-checkbox__box"
@@ -362,7 +362,7 @@ exports[`Checkbox should render with default values if optional ones were not pa
     class="quill-checkbox"
   >
     <div
-      class="quill-checkbox__wrapper"
+      class="quill-checkbox__wrapper quill-checkbox__wrapper--left"
     >
       <input
         class="quill-checkbox__box"

--- a/lib/components/SelectionControl/checkbox/checkbox-single/__tests__/__snapshots__/checkbox.test.tsx.snap
+++ b/lib/components/SelectionControl/checkbox/checkbox-single/__tests__/__snapshots__/checkbox.test.tsx.snap
@@ -36,6 +36,42 @@ exports[`Checkbox should apply className if it was passed 1`] = `
 </div>
 `;
 
+exports[`Checkbox should apply correct className if checkboxPosition is 'right' 1`] = `
+<div>
+  <div
+    class="quill-checkbox"
+  >
+    <div
+      class="quill-checkbox__wrapper quill-checkbox__wrapper--right"
+    >
+      <input
+        class="quill-checkbox__box"
+        type="checkbox"
+      />
+      <svg
+        class="quill-checkbox__box-icon quill-checkbox__box-icon--pale"
+        height="24"
+        role="img"
+        viewBox="0 0 32 32"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M22.25 9.625H9.75a.64.64 0 0 0-.625.625v12.5c0 .352.273.625.625.625h12.5a.64.64 0 0 0 .625-.625v-12.5c0-.312-.312-.625-.625-.625M9.75 7.75h12.5c1.367 0 2.5 1.133 2.5 2.5v12.5c0 1.406-1.133 2.5-2.5 2.5H9.75a2.47 2.47 0 0 1-2.5-2.5v-12.5c0-1.367 1.094-2.5 2.5-2.5"
+        />
+      </svg>
+    </div>
+    <label>
+      <span
+        class="quill-typography__body-text__size--sm__weight--regular__decoration--default quill-typography__color--default quill-checkbox__label"
+      >
+        Checkbox label
+      </span>
+    </label>
+  </div>
+</div>
+`;
+
 exports[`Checkbox should apply id if it was passed 1`] = `
 <div>
   <div

--- a/lib/components/SelectionControl/checkbox/checkbox-single/__tests__/checkbox.test.tsx
+++ b/lib/components/SelectionControl/checkbox/checkbox-single/__tests__/checkbox.test.tsx
@@ -50,6 +50,14 @@ describe("Checkbox", () => {
         expect(container).toMatchSnapshot();
     });
 
+    it("should apply correct className if checkboxPosition is 'right'", () => {
+        const { container } = render(
+            <Checkbox {...mockProps} checkboxPosition="right" />,
+        );
+
+        expect(container).toMatchSnapshot();
+    });
+
     it("should apply className if it was passed", () => {
         const { container } = render(
             <Checkbox {...mockProps} className="wrapper_className" />,

--- a/lib/components/SelectionControl/checkbox/checkbox-single/checkbox.scss
+++ b/lib/components/SelectionControl/checkbox/checkbox-single/checkbox.scss
@@ -8,6 +8,10 @@
         height: var(--size-generic-sm);
         width: var(--size-generic-sm);
         position: relative;
+
+        &--right {
+            order: 3;
+        }
     }
 
     &__box {

--- a/lib/components/SelectionControl/checkbox/checkbox-single/checkbox.stories.tsx
+++ b/lib/components/SelectionControl/checkbox/checkbox-single/checkbox.stories.tsx
@@ -9,6 +9,7 @@ const meta = {
     tags: ["autodocs"],
     args: {
         checked: false,
+        checkboxPosition: "left",
         disabled: false,
         indeterminate: false,
         showInfoIcon: false,
@@ -24,6 +25,13 @@ const meta = {
             description: "Flag for setting initial state",
             options: ["true", "false"],
             control: { type: "boolean" },
+        },
+        checkboxPosition: {
+            table: { type: { summary: "left |right | undefined" } },
+            description:
+                "String for determining checkbox position. Default value - 'left'",
+            options: ["left", "right"],
+            control: { type: "radio" },
         },
         disabled: {
             table: { type: { summary: "boolean | undefined" } },
@@ -158,6 +166,11 @@ export const CheckboxMd: Story = {
     args: {
         size: "md",
         label: "Selection control checkbox md size",
+    },
+};
+export const CheckboxWithRightPosition: Story = {
+    args: {
+        checkboxPosition: "right",
     },
 };
 

--- a/lib/components/SelectionControl/checkbox/checkbox-single/checkbox.stories.tsx
+++ b/lib/components/SelectionControl/checkbox/checkbox-single/checkbox.stories.tsx
@@ -27,7 +27,7 @@ const meta = {
             control: { type: "boolean" },
         },
         checkboxPosition: {
-            table: { type: { summary: "left |right | undefined" } },
+            table: { type: { summary: "left | right | undefined" } },
             description:
                 "String for determining checkbox position. Default value - 'left'",
             options: ["left", "right"],

--- a/lib/components/SelectionControl/checkbox/checkbox-single/index.tsx
+++ b/lib/components/SelectionControl/checkbox/checkbox-single/index.tsx
@@ -14,7 +14,7 @@ import {
     LabelPairedCircleInfoSmRegularIcon,
     LabelPairedCircleInfoMdRegularIcon,
 } from "@deriv/quill-icons";
-import { TMediumSizes } from "@types";
+import { TMediumSizes, TLeftOrRight } from "@types";
 import { Text } from "@components/Typography";
 import { KEY } from "@utils/common-utils";
 
@@ -35,7 +35,7 @@ export interface CheckboxProps
             | React.KeyboardEvent<HTMLSpanElement>,
     ) => void;
     className?: string;
-    checkboxPosition?: "left" | "right";
+    checkboxPosition?: TLeftOrRight;
 }
 
 export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(

--- a/lib/components/SelectionControl/checkbox/checkbox-single/index.tsx
+++ b/lib/components/SelectionControl/checkbox/checkbox-single/index.tsx
@@ -35,6 +35,7 @@ export interface CheckboxProps
             | React.KeyboardEvent<HTMLSpanElement>,
     ) => void;
     className?: string;
+    checkboxPosition?: "left" | "right";
 }
 
 export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
@@ -51,6 +52,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
             name,
             onChange,
             className,
+            checkboxPosition = "left",
             ...rest
         },
         ref,
@@ -123,7 +125,12 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
                     className,
                 )}
             >
-                <div className="quill-checkbox__wrapper">
+                <div
+                    className={clsx("quill-checkbox__wrapper", {
+                        "quill-checkbox__wrapper--right":
+                            checkboxPosition === "right",
+                    })}
+                >
                     <input
                         {...rest}
                         id={rest.id ?? name}

--- a/lib/components/SelectionControl/checkbox/checkbox-single/index.tsx
+++ b/lib/components/SelectionControl/checkbox/checkbox-single/index.tsx
@@ -126,10 +126,10 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
                 )}
             >
                 <div
-                    className={clsx("quill-checkbox__wrapper", {
-                        "quill-checkbox__wrapper--right":
-                            checkboxPosition === "right",
-                    })}
+                    className={clsx(
+                        "quill-checkbox__wrapper",
+                        `quill-checkbox__wrapper--${checkboxPosition}`,
+                    )}
                 >
                     <input
                         {...rest}


### PR DESCRIPTION
Add `checkboxPosition` prop, which controls `left` or `right` positioning. Prop is based on css property `order` for flex-elements.

https://github.com/deriv-com/quill-ui/assets/121025168/9ac10993-9c46-4eb3-9599-96b5b170ed69

