### PR TITLE
DTRA / Kate / Action sheet refactor: expand types and change css

### DIFF
--- a/lib/components/ActionSheet/header/header.scss
+++ b/lib/components/ActionSheet/header/header.scss
@@ -19,21 +19,17 @@
 
     &--title {
         display: flex;
-        justify-content: space-between;
-        padding: var(--component-actionSheet-spacing-padding-sm)
+        justify-content: center;
+        margin: var(--component-actionSheet-spacing-padding-sm)
             var(--component-actionSheet-spacing-padding-md);
         gap: var(--component-actionSheet-spacing-gap-md);
         align-items: center;
-        flex-direction: row-reverse;
+        position: relative;
+        height: var(--core-size-2400);
 
         @include breakpoint("lg") {
-            flex-direction: row;
-            padding: var(--component-actionSheet-spacing-padding-md)
+            margin: var(--component-actionSheet-spacing-padding-md)
                 var(--component-actionSheet-spacing-padding-lg);
-        }
-
-        & > h5 {
-            flex: 1;
         }
 
         &--icon {
@@ -44,8 +40,15 @@
             align-items: center;
             border-radius: var(--component-button-border-radius-lg);
             fill: var(--component-textIcon-normal-prominent);
+            position: absolute;
+            top: 0;
+            left: 0;
 
             &--close {
+                position: absolute;
+                top: 0;
+                right: 0;
+                left: unset;
                 display: none;
                 cursor: pointer;
 

--- a/lib/components/ActionSheet/header/header.scss
+++ b/lib/components/ActionSheet/header/header.scss
@@ -46,11 +46,11 @@
             fill: var(--component-textIcon-normal-prominent);
 
             &--close {
-                visibility: hidden;
+                display: none;
                 cursor: pointer;
 
                 @include breakpoint("lg") {
-                    visibility: visible;
+                    display: flex;
                 }
             }
         }

--- a/lib/components/ActionSheet/header/index.tsx
+++ b/lib/components/ActionSheet/header/index.tsx
@@ -4,9 +4,9 @@ import clsx from "clsx";
 import "./header.scss";
 import { Heading, Text } from "@components/Typography";
 
-interface HeaderProps extends ComponentPropsWithoutRef<"div"> {
-    title?: string;
-    description?: string;
+interface HeaderProps extends Omit<ComponentPropsWithoutRef<"div">, "title"> {
+    title?: ReactNode;
+    description?: ReactNode;
     icon?: ReactNode;
     closeIcon?: ReactNode;
 }
@@ -33,18 +33,26 @@ const Header = ({
             {...rest}
         >
             <div className="quill-action-sheet--title">
-                <div className="quill-action-sheet--title--icon">{Icon}</div>
-                <Heading.H5>{title}</Heading.H5>
-                <button
-                    className="quill-action-sheet--title--icon quill-action-sheet--title--icon--close"
-                    onClick={handleClose}
-                >
-                    {CloseIcon}
-                </button>
+                {Icon && (
+                    <div className="quill-action-sheet--title--icon">
+                        {Icon}
+                    </div>
+                )}
+                {title && <Heading.H5>{title}</Heading.H5>}
+                {CloseIcon && (
+                    <button
+                        className="quill-action-sheet--title--icon quill-action-sheet--title--icon--close"
+                        onClick={handleClose}
+                    >
+                        {CloseIcon}
+                    </button>
+                )}
             </div>
-            <Text className="quill-action-sheet--description">
-                {description}
-            </Text>
+            {description && (
+                <Text className="quill-action-sheet--description">
+                    {description}
+                </Text>
+            )}
         </div>
     );
 };

--- a/lib/components/ActionSheet/portal/portal.scss
+++ b/lib/components/ActionSheet/portal/portal.scss
@@ -38,7 +38,7 @@
         margin-right: auto;
         display: flex;
         max-height: 90vh;
-        min-width: 320px;
+        width: 100%;
         max-width: 800px;
         flex-direction: column;
         overflow-y: auto;


### PR DESCRIPTION
- Add conditional rendering inside of action sheet header as some parts were optional;
- Changed `width`: now it's 100% with `max-width` 800px. Previously, instead of `width` 100% was `min-width` 320px, which caused problems: if there was not enough content inside of action sheet, it became 320px even if the mobile was 360px.
- Change css for buttons in header: make the with absolute positioning and add `display: none` for mobile instead of changing `visibility`.


https://github.com/deriv-com/quill-ui/assets/121025168/ff0da0a6-6947-4857-a2a4-e940d34ef348

