### PR TITLE
DTRA / Kate / Add more props for Action Sheet footer

### DIFF
--- a/lib/components/ActionSheet/button-trigger.stories.tsx
+++ b/lib/components/ActionSheet/button-trigger.stories.tsx
@@ -82,6 +82,20 @@ const meta: Meta = {
             },
             description: "Same as `primaryAction`",
         },
+        shouldCloseOnPrimaryButtonClick: {
+            table: { type: { summary: "boolean | undefined" } },
+            options: ["true", "false"],
+            control: { type: "boolean" },
+            description:
+                "This prop controls if Action Sheet should be closed or not when primary button was clicked. Default value: true",
+        },
+        shouldCloseOnSecondaryButtonClick: {
+            table: { type: { summary: "boolean | undefined" } },
+            options: ["true", "false"],
+            control: { type: "boolean" },
+            description:
+                "This prop controls if Action Sheet should be closed or not when secondary button was clicked. Default value: true",
+        },
         alignment: {
             control: {
                 type: "radio",

--- a/lib/components/ActionSheet/controlled.stories.tsx
+++ b/lib/components/ActionSheet/controlled.stories.tsx
@@ -83,6 +83,20 @@ const meta: Meta = {
             },
             description: "Same as `primaryAction`",
         },
+        shouldCloseOnPrimaryButtonClick: {
+            table: { type: { summary: "boolean | undefined" } },
+            options: ["true", "false"],
+            control: { type: "boolean" },
+            description:
+                "This prop controls if Action Sheet should be closed or not when primary button was clicked. Default value: true",
+        },
+        shouldCloseOnSecondaryButtonClick: {
+            table: { type: { summary: "boolean | undefined" } },
+            options: ["true", "false"],
+            control: { type: "boolean" },
+            description:
+                "This prop controls if Action Sheet should be closed or not when secondary button was clicked. Default value: true",
+        },
         alignment: {
             control: {
                 type: "radio",

--- a/lib/components/ActionSheet/footer/__tests__/footer.test.tsx
+++ b/lib/components/ActionSheet/footer/__tests__/footer.test.tsx
@@ -73,4 +73,23 @@ describe("<ActionSheet.Footer/>", () => {
             expect(footer).toMatchSnapshot();
         });
     });
+    it("should not close the component if user clicked on primary button and shouldCloseOnPrimaryButtonClick === false", async () => {
+        const onActionButton = jest.fn();
+        render(
+            <ActionSheet.Footer
+                primaryAction={{
+                    content: "Primary action",
+                    onAction: onActionButton,
+                }}
+                shouldCloseOnPrimaryButtonClick={false}
+            />,
+        );
+        const primaryBtn = screen.getByRole("button", {
+            name: "Primary action",
+        });
+        expect(primaryBtn).toBeInTheDocument();
+        await userEvent.click(primaryBtn);
+        expect(onActionButton).toHaveBeenCalled();
+        expect(primaryBtn).toBeInTheDocument();
+    });
 });

--- a/lib/components/ActionSheet/footer/index.tsx
+++ b/lib/components/ActionSheet/footer/index.tsx
@@ -10,6 +10,8 @@ const Footer = ({
     secondaryAction,
     alignment,
     className,
+    shouldCloseOnPrimaryButtonClick = true,
+    shouldCloseOnSecondaryButtonClick = true,
     ...rest
 }: FooterProps) => {
     const { handleClose } = useContext(ActionSheetContext);
@@ -17,12 +19,12 @@ const Footer = ({
 
     const primaryActionHandler = () => {
         primaryAction?.onAction();
-        handleClose?.();
+        if (shouldCloseOnPrimaryButtonClick) handleClose?.();
     };
 
     const secondaryActionHandler = () => {
         secondaryAction?.onAction();
-        handleClose?.();
+        if (shouldCloseOnSecondaryButtonClick) handleClose?.();
     };
 
     return (

--- a/lib/components/ActionSheet/icon-trigger.stories.tsx
+++ b/lib/components/ActionSheet/icon-trigger.stories.tsx
@@ -69,6 +69,20 @@ const meta: Meta = {
             },
             description: "Same as `primaryAction`",
         },
+        shouldCloseOnPrimaryButtonClick: {
+            table: { type: { summary: "boolean | undefined" } },
+            options: ["true", "false"],
+            control: { type: "boolean" },
+            description:
+                "This prop controls if Action Sheet should be closed or not when primary button was clicked. Default value: true",
+        },
+        shouldCloseOnSecondaryButtonClick: {
+            table: { type: { summary: "boolean | undefined" } },
+            options: ["true", "false"],
+            control: { type: "boolean" },
+            description:
+                "This prop controls if Action Sheet should be closed or not when secondary button was clicked. Default value: true",
+        },
         icon: {
             description:
                 "This props allowed you to pass in icon for `ActionSheet.Header`",

--- a/lib/components/ActionSheet/mocks/example.tsx
+++ b/lib/components/ActionSheet/mocks/example.tsx
@@ -19,6 +19,8 @@ export const ActionSheetExample = ({
     title,
     closeIcon,
     icon,
+    shouldCloseOnPrimaryButtonClick,
+    shouldCloseOnSecondaryButtonClick,
     ...props
 }: ExampleProps) => {
     const [open, setOpen] = useState<boolean>();
@@ -57,6 +59,12 @@ export const ActionSheetExample = ({
                         primaryAction={primaryAction}
                         secondaryAction={secondaryAction}
                         alignment={alignment}
+                        shouldCloseOnPrimaryButtonClick={
+                            shouldCloseOnPrimaryButtonClick
+                        }
+                        shouldCloseOnSecondaryButtonClick={
+                            shouldCloseOnSecondaryButtonClick
+                        }
                     />
                 </ActionSheet.Portal>
             </ActionSheet.Root>
@@ -72,6 +80,8 @@ export const ActionSheetExampleWithIconTrigger = ({
     title,
     closeIcon,
     icon,
+    shouldCloseOnPrimaryButtonClick,
+    shouldCloseOnSecondaryButtonClick,
     ...props
 }: ExampleProps) => {
     return (
@@ -159,6 +169,12 @@ export const ActionSheetExampleWithIconTrigger = ({
                         primaryAction={primaryAction}
                         secondaryAction={secondaryAction}
                         alignment={alignment}
+                        shouldCloseOnPrimaryButtonClick={
+                            shouldCloseOnPrimaryButtonClick
+                        }
+                        shouldCloseOnSecondaryButtonClick={
+                            shouldCloseOnSecondaryButtonClick
+                        }
                     />
                 </ActionSheet.Portal>
             </ActionSheet.Root>
@@ -174,6 +190,8 @@ export const ActionSheetExampleControlled = ({
     title,
     closeIcon,
     icon,
+    shouldCloseOnPrimaryButtonClick,
+    shouldCloseOnSecondaryButtonClick,
     ...props
 }: ExampleProps) => {
     return (
@@ -207,6 +225,12 @@ export const ActionSheetExampleControlled = ({
                         primaryAction={primaryAction}
                         secondaryAction={secondaryAction}
                         alignment={alignment}
+                        shouldCloseOnPrimaryButtonClick={
+                            shouldCloseOnPrimaryButtonClick
+                        }
+                        shouldCloseOnSecondaryButtonClick={
+                            shouldCloseOnSecondaryButtonClick
+                        }
                     />
                 </ActionSheet.Portal>
             </ActionSheet.Root>

--- a/lib/components/ActionSheet/types.ts
+++ b/lib/components/ActionSheet/types.ts
@@ -36,6 +36,8 @@ export interface FooterProps
         actionSheetFooterCVA {
     primaryAction?: ActionType;
     secondaryAction?: ActionType;
+    shouldCloseOnPrimaryButtonClick?: boolean;
+    shouldCloseOnSecondaryButtonClick?: boolean;
 }
 
 export type FooterAlignment = FooterProps["alignment"];


### PR DESCRIPTION
- Added `shouldCloseOnPrimaryButtonClick?: boolean;` and `shouldCloseOnSecondaryButtonClick?: boolean;` for Footer Action Sheet props for controlling if the component should be closed or not. Default value is `true`.


https://github.com/deriv-com/quill-ui/assets/121025168/2945d857-261f-47c3-be8c-7bbdacd20682

