### PR TITLE
DTRA-1279 / Kate / Add prop for disabling footer Action sheet buttons

### DIFF
--- a/lib/components/ActionSheet/button-trigger.stories.tsx
+++ b/lib/components/ActionSheet/button-trigger.stories.tsx
@@ -26,12 +26,12 @@ const meta: Meta = {
         isPrimaryButtonDisabled: {
             control: { type: "boolean" },
             description:
-                "This prop controls if primary button is disabled or not. Default value: false",
+                "This prop controls if primary button is disabled or not.",
         },
         isSecondaryButtonDisabled: {
             control: { type: "boolean" },
             description:
-                "This prop controls if secondary button is disabled or not. Default value: false",
+                "This prop controls if secondary button is disabled or not.",
         },
         show: { table: { disable: true } },
         handleOpen: { table: { disable: true } },

--- a/lib/components/ActionSheet/button-trigger.stories.tsx
+++ b/lib/components/ActionSheet/button-trigger.stories.tsx
@@ -23,6 +23,16 @@ const meta: Meta = {
     },
     argTypes: {
         isOpen: { table: { disable: true } },
+        isPrimaryButtonDisabled: {
+            control: { type: "boolean" },
+            description:
+                "This prop controls if primary button is disabled or not. Default value: false",
+        },
+        isSecondaryButtonDisabled: {
+            control: { type: "boolean" },
+            description:
+                "This prop controls if secondary button is disabled or not. Default value: false",
+        },
         show: { table: { disable: true } },
         handleOpen: { table: { disable: true } },
         handleClose: { table: { disable: true } },

--- a/lib/components/ActionSheet/controlled.stories.tsx
+++ b/lib/components/ActionSheet/controlled.stories.tsx
@@ -34,6 +34,16 @@ const meta: Meta = {
                 "If you wish to manage the opening and closing states, transmit the `open` state from your component. Set the initial value to `false` when passing it.",
             control: { type: "boolean" },
         },
+        isPrimaryButtonDisabled: {
+            control: { type: "boolean" },
+            description:
+                "This prop controls if primary button is disabled or not.",
+        },
+        isSecondaryButtonDisabled: {
+            control: { type: "boolean" },
+            description:
+                "This prop controls if secondary button is disabled or not.",
+        },
         show: { table: { disable: true } },
         handleOpen: { table: { disable: true } },
         handleClose: { table: { disable: true } },

--- a/lib/components/ActionSheet/footer/__tests__/footer.test.tsx
+++ b/lib/components/ActionSheet/footer/__tests__/footer.test.tsx
@@ -92,4 +92,22 @@ describe("<ActionSheet.Footer/>", () => {
         expect(onActionButton).toHaveBeenCalled();
         expect(primaryBtn).toBeInTheDocument();
     });
+    it("should disable button and do not call a function onAction if isPrimaryButtonDisabled === true", async () => {
+        const onActionButton = jest.fn();
+        render(
+            <ActionSheet.Footer
+                primaryAction={{
+                    content: "Primary action",
+                    onAction: onActionButton,
+                }}
+                isPrimaryButtonDisabled={true}
+            />,
+        );
+        const primaryBtn = screen.getByRole("button", {
+            name: "Primary action",
+        });
+        await userEvent.click(primaryBtn);
+        expect(onActionButton).not.toHaveBeenCalled();
+        expect(primaryBtn).toBeDisabled();
+    });
 });

--- a/lib/components/ActionSheet/footer/__tests__/footer.test.tsx
+++ b/lib/components/ActionSheet/footer/__tests__/footer.test.tsx
@@ -100,7 +100,7 @@ describe("<ActionSheet.Footer/>", () => {
                     content: "Primary action",
                     onAction: onActionButton,
                 }}
-                isPrimaryButtonDisabled={true}
+                isPrimaryButtonDisabled
             />,
         );
         const primaryBtn = screen.getByRole("button", {

--- a/lib/components/ActionSheet/footer/index.tsx
+++ b/lib/components/ActionSheet/footer/index.tsx
@@ -12,8 +12,8 @@ const Footer = ({
     className,
     shouldCloseOnPrimaryButtonClick = true,
     shouldCloseOnSecondaryButtonClick = true,
-    isPrimaryButtonDisabled = false,
-    isSecondaryButtonDisabled = false,
+    isPrimaryButtonDisabled,
+    isSecondaryButtonDisabled,
     ...rest
 }: FooterProps) => {
     const { handleClose } = useContext(ActionSheetContext);

--- a/lib/components/ActionSheet/footer/index.tsx
+++ b/lib/components/ActionSheet/footer/index.tsx
@@ -12,6 +12,8 @@ const Footer = ({
     className,
     shouldCloseOnPrimaryButtonClick = true,
     shouldCloseOnSecondaryButtonClick = true,
+    isPrimaryButtonDisabled = false,
+    isSecondaryButtonDisabled = false,
     ...rest
 }: FooterProps) => {
     const { handleClose } = useContext(ActionSheetContext);
@@ -43,6 +45,7 @@ const Footer = ({
                     size="lg"
                     label={primaryAction.content}
                     fullWidth
+                    disabled={isPrimaryButtonDisabled}
                 />
             )}
             {secondaryAction && (
@@ -53,6 +56,7 @@ const Footer = ({
                     size="lg"
                     label={secondaryAction.content}
                     fullWidth
+                    disabled={isSecondaryButtonDisabled}
                 />
             )}
         </div>

--- a/lib/components/ActionSheet/icon-trigger.stories.tsx
+++ b/lib/components/ActionSheet/icon-trigger.stories.tsx
@@ -29,6 +29,16 @@ const meta: Meta = {
     },
     argTypes: {
         isOpen: { table: { disable: true } },
+        isPrimaryButtonDisabled: {
+            control: { type: "boolean" },
+            description:
+                "This prop controls if primary button is disabled or not.",
+        },
+        isSecondaryButtonDisabled: {
+            control: { type: "boolean" },
+            description:
+                "This prop controls if secondary button is disabled or not.",
+        },
         show: { table: { disable: true } },
         handleOpen: { table: { disable: true } },
         handleClose: { table: { disable: true } },

--- a/lib/components/ActionSheet/mocks/example.tsx
+++ b/lib/components/ActionSheet/mocks/example.tsx
@@ -21,6 +21,8 @@ export const ActionSheetExample = ({
     icon,
     shouldCloseOnPrimaryButtonClick,
     shouldCloseOnSecondaryButtonClick,
+    isPrimaryButtonDisabled,
+    isSecondaryButtonDisabled,
     ...props
 }: ExampleProps) => {
     const [open, setOpen] = useState<boolean>();
@@ -65,6 +67,8 @@ export const ActionSheetExample = ({
                         shouldCloseOnSecondaryButtonClick={
                             shouldCloseOnSecondaryButtonClick
                         }
+                        isPrimaryButtonDisabled={isPrimaryButtonDisabled}
+                        isSecondaryButtonDisabled={isSecondaryButtonDisabled}
                     />
                 </ActionSheet.Portal>
             </ActionSheet.Root>
@@ -82,6 +86,8 @@ export const ActionSheetExampleWithIconTrigger = ({
     icon,
     shouldCloseOnPrimaryButtonClick,
     shouldCloseOnSecondaryButtonClick,
+    isPrimaryButtonDisabled,
+    isSecondaryButtonDisabled,
     ...props
 }: ExampleProps) => {
     return (
@@ -175,6 +181,8 @@ export const ActionSheetExampleWithIconTrigger = ({
                         shouldCloseOnSecondaryButtonClick={
                             shouldCloseOnSecondaryButtonClick
                         }
+                        isPrimaryButtonDisabled={isPrimaryButtonDisabled}
+                        isSecondaryButtonDisabled={isSecondaryButtonDisabled}
                     />
                 </ActionSheet.Portal>
             </ActionSheet.Root>
@@ -192,6 +200,8 @@ export const ActionSheetExampleControlled = ({
     icon,
     shouldCloseOnPrimaryButtonClick,
     shouldCloseOnSecondaryButtonClick,
+    isPrimaryButtonDisabled,
+    isSecondaryButtonDisabled,
     ...props
 }: ExampleProps) => {
     return (
@@ -231,6 +241,8 @@ export const ActionSheetExampleControlled = ({
                         shouldCloseOnSecondaryButtonClick={
                             shouldCloseOnSecondaryButtonClick
                         }
+                        isPrimaryButtonDisabled={isPrimaryButtonDisabled}
+                        isSecondaryButtonDisabled={isSecondaryButtonDisabled}
                     />
                 </ActionSheet.Portal>
             </ActionSheet.Root>

--- a/lib/components/ActionSheet/types.ts
+++ b/lib/components/ActionSheet/types.ts
@@ -38,6 +38,8 @@ export interface FooterProps
     secondaryAction?: ActionType;
     shouldCloseOnPrimaryButtonClick?: boolean;
     shouldCloseOnSecondaryButtonClick?: boolean;
+    isPrimaryButtonDisabled?: boolean;
+    isSecondaryButtonDisabled?: boolean;
 }
 
 export type FooterAlignment = FooterProps["alignment"];


### PR DESCRIPTION
- Add `isPrimaryButtonDisabled = false` and `isSecondaryButtonDisabled = false` to the Footer Action Sheet for disabling buttons. By default props are false.
- Add test cases
- Add to the story documentation

https://github.com/deriv-com/quill-ui/assets/121025168/103da589-0aa3-4356-ac6c-e179a68969a2

