### PR TITLE
Prince/fix generation of shadow values

### DIFF
--- a/lib/styles/quill/quill.scss
+++ b/lib/styles/quill/quill.scss
@@ -562,63 +562,63 @@
         var(--core-color-opacity-overflow-300) 1.63%,
         var(--core-color-solid-slate-1200) 49.98%
     );
-    --core-elevation-shadow-50: 0 0 0 0;
-    --core-elevation-shadow-110: 0 -1 2 0 rgba(0, 0, 0, 6%),
-        0 -1 2 0 rgba(0, 0, 0, 3%);
-    --core-elevation-shadow-120: 1 0 2 0 rgba(0, 0, 0, 6%),
-        1 0 2 0 rgba(0, 0, 0, 3%);
-    --core-elevation-shadow-130: 0 1 2 0 rgba(0, 0, 0, 6%),
-        0 1 2 0 rgba(0, 0, 0, 3%);
-    --core-elevation-shadow-140: -1 0 2 0 rgba(0, 0, 0, 6%),
-        -1 0 2 0 rgba(0, 0, 0, 3%);
-    --core-elevation-shadow-210: 0 -1 4 0 rgba(0, 0, 0, 8%),
-        0 -1 4 0 rgba(0, 0, 0, 4%);
-    --core-elevation-shadow-220: 1 0 4 0 rgba(0, 0, 0, 8%),
-        1 0 4 0 rgba(0, 0, 0, 4%);
-    --core-elevation-shadow-230: 0 1 4 0 rgba(0, 0, 0, 8%),
-        0 1 4 0 rgba(0, 0, 0, 4%);
-    --core-elevation-shadow-240: -1 0 4 0 rgba(0, 0, 0, 8%),
-        -1 0 4 0 rgba(0, 0, 0, 4%);
-    --core-elevation-shadow-310: 0 -4 8 2 rgba(0, 0, 0, 3%),
-        0 -4 8 2 rgba(0, 0, 0, 2%);
-    --core-elevation-shadow-320: 4 0 8 2 rgba(0, 0, 0, 3%),
-        4 0 8 2 rgba(0, 0, 0, 2%);
-    --core-elevation-shadow-330: 0 4 8 2 rgba(0, 0, 0, 3%),
-        0 4 8 2 rgba(0, 0, 0, 2%);
-    --core-elevation-shadow-340: -4 0 8 2 rgba(0, 0, 0, 3%),
-        -4 0 8 2 rgba(0, 0, 0, 2%);
-    --core-elevation-shadow-410: 0 -8 16 2 rgba(0, 0, 0, 4%),
-        0 -8 16 2 rgba(0, 0, 0, 2%);
-    --core-elevation-shadow-420: 8 0 16 2 rgba(0, 0, 0, 4%),
-        8 0 16 2 rgba(0, 0, 0, 2%);
-    --core-elevation-shadow-430: 0 8 16 2 rgba(0, 0, 0, 4%),
-        0 8 16 2 rgba(0, 0, 0, 2%);
-    --core-elevation-shadow-440: -8 0 16 2 rgba(0, 0, 0, 4%),
-        -8 0 16 2 rgba(0, 0, 0, 2%);
-    --core-elevation-shadow-510: 0 -16 24 4 rgba(0, 0, 0, 4%),
-        0 -16 24 4 rgba(0, 0, 0, 2%);
-    --core-elevation-shadow-520: 16 0 24 4 rgba(0, 0, 0, 4%),
-        16 0 24 4 rgba(0, 0, 0, 2%);
-    --core-elevation-shadow-530: 0 16 24 4 rgba(0, 0, 0, 4%),
-        0 16 24 4 rgba(0, 0, 0, 2%);
-    --core-elevation-shadow-540: -16 0 24 4 rgba(0, 0, 0, 4%),
-        -16 0 24 4 rgba(0, 0, 0, 2%);
-    --core-elevation-shadow-610: 0 -24 48 8 rgba(0, 0, 0, 6%),
-        0 -24 48 8 rgba(0, 0, 0, 3%);
-    --core-elevation-shadow-620: 24 0 48 8 rgba(0, 0, 0, 6%),
-        24 0 48 8 rgba(0, 0, 0, 3%);
-    --core-elevation-shadow-630: 0 24 48 8 rgba(0, 0, 0, 6%),
-        0 24 48 8 rgba(0, 0, 0, 3%);
-    --core-elevation-shadow-640: -24 0 48 8 rgba(0, 0, 0, 6%),
-        -24 0 48 8 rgba(0, 0, 0, 3%);
-    --core-elevation-shadow-710: 0 -32 64 12 rgba(0, 0, 0, 8%),
-        0 -32 64 12 rgba(0, 0, 0, 4%);
-    --core-elevation-shadow-720: 32 0 64 12 rgba(0, 0, 0, 8%),
-        32 0 64 12 rgba(0, 0, 0, 4%);
-    --core-elevation-shadow-730: 0 32 64 12 rgba(0, 0, 0, 8%),
-        0 32 64 12 rgba(0, 0, 0, 4%);
-    --core-elevation-shadow-740: -32 0 64 12 rgba(0, 0, 0, 8%),
-        -32 0 64 12 rgba(0, 0, 0, 4%);
+    --core-elevation-shadow-50: 0px 0px 0px 0px;
+    --core-elevation-shadow-110: 0px -1px 2px 0px rgba(0, 0, 0, 6%),
+        0px -1px 2px 0px rgba(0, 0, 0, 3%);
+    --core-elevation-shadow-120: 1px 0px 2px 0px rgba(0, 0, 0, 6%),
+        1px 0px 2px 0px rgba(0, 0, 0, 3%);
+    --core-elevation-shadow-130: 0px 1px 2px 0px rgba(0, 0, 0, 6%),
+        0px 1px 2px 0px rgba(0, 0, 0, 3%);
+    --core-elevation-shadow-140: -1px 0px 2px 0px rgba(0, 0, 0, 6%),
+        -1px 0px 2px 0px rgba(0, 0, 0, 3%);
+    --core-elevation-shadow-210: 0px -1px 4px 0px rgba(0, 0, 0, 8%),
+        0px -1px 4px 0px rgba(0, 0, 0, 4%);
+    --core-elevation-shadow-220: 1px 0px 4px 0px rgba(0, 0, 0, 8%),
+        1px 0px 4px 0px rgba(0, 0, 0, 4%);
+    --core-elevation-shadow-230: 0px 1px 4px 0px rgba(0, 0, 0, 8%),
+        0px 1px 4px 0px rgba(0, 0, 0, 4%);
+    --core-elevation-shadow-240: -1px 0px 4px 0px rgba(0, 0, 0, 8%),
+        -1px 0px 4px 0px rgba(0, 0, 0, 4%);
+    --core-elevation-shadow-310: 0px -4px 8px 2px rgba(0, 0, 0, 3%),
+        0px -4px 8px 2px rgba(0, 0, 0, 2%);
+    --core-elevation-shadow-320: 4px 0px 8px 2px rgba(0, 0, 0, 3%),
+        4px 0px 8px 2px rgba(0, 0, 0, 2%);
+    --core-elevation-shadow-330: 0px 4px 8px 2px rgba(0, 0, 0, 3%),
+        0px 4px 8px 2px rgba(0, 0, 0, 2%);
+    --core-elevation-shadow-340: -4px 0px 8px 2px rgba(0, 0, 0, 3%),
+        -4px 0px 8px 2px rgba(0, 0, 0, 2%);
+    --core-elevation-shadow-410: 0px -8px 16px 2px rgba(0, 0, 0, 4%),
+        0px -8px 16px 2px rgba(0, 0, 0, 2%);
+    --core-elevation-shadow-420: 8px 0px 16px 2px rgba(0, 0, 0, 4%),
+        8px 0px 16px 2px rgba(0, 0, 0, 2%);
+    --core-elevation-shadow-430: 0px 8px 16px 2px rgba(0, 0, 0, 4%),
+        0px 8px 16px 2px rgba(0, 0, 0, 2%);
+    --core-elevation-shadow-440: -8px 0px 16px 2px rgba(0, 0, 0, 4%),
+        -8px 0px 16px 2px rgba(0, 0, 0, 2%);
+    --core-elevation-shadow-510: 0px -16px 24px 4px rgba(0, 0, 0, 4%),
+        0px -16px 24px 4px rgba(0, 0, 0, 2%);
+    --core-elevation-shadow-520: 16px 0px 24px 4px rgba(0, 0, 0, 4%),
+        16px 0px 24px 4px rgba(0, 0, 0, 2%);
+    --core-elevation-shadow-530: 0px 16px 24px 4px rgba(0, 0, 0, 4%),
+        0px 16px 24px 4px rgba(0, 0, 0, 2%);
+    --core-elevation-shadow-540: -16px 0px 24px 4px rgba(0, 0, 0, 4%),
+        -16px 0px 24px 4px rgba(0, 0, 0, 2%);
+    --core-elevation-shadow-610: 0px -24px 48px 8px rgba(0, 0, 0, 6%),
+        0px -24px 48px 8px rgba(0, 0, 0, 3%);
+    --core-elevation-shadow-620: 24px 0px 48px 8px rgba(0, 0, 0, 6%),
+        24px 0px 48px 8px rgba(0, 0, 0, 3%);
+    --core-elevation-shadow-630: 0px 24px 48px 8px rgba(0, 0, 0, 6%),
+        0px 24px 48px 8px rgba(0, 0, 0, 3%);
+    --core-elevation-shadow-640: -24px 0px 48px 8px rgba(0, 0, 0, 6%),
+        -24px 0px 48px 8px rgba(0, 0, 0, 3%);
+    --core-elevation-shadow-710: 0px -32px 64px 12px rgba(0, 0, 0, 8%),
+        0px -32px 64px 12px rgba(0, 0, 0, 4%);
+    --core-elevation-shadow-720: 32px 0px 64px 12px rgba(0, 0, 0, 8%),
+        32px 0px 64px 12px rgba(0, 0, 0, 4%);
+    --core-elevation-shadow-730: 0px 32px 64px 12px rgba(0, 0, 0, 8%),
+        0px 32px 64px 12px rgba(0, 0, 0, 4%);
+    --core-elevation-shadow-740: -32px 0px 64px 12px rgba(0, 0, 0, 8%),
+        -32px 0px 64px 12px rgba(0, 0, 0, 4%);
     --core-opacity-50: 0;
     --core-opacity-75: 0.04;
     --core-opacity-100: 0.08;

--- a/scripts/transformer.js
+++ b/scripts/transformer.js
@@ -67,6 +67,36 @@ class Transformer {
         this.generateFiles();
     }
 
+    addPxToShadows = (cssString) => {
+        const shadowKeys = ["elevation"];
+
+        // Regular expression to match numeric values within the rules (not keys), excluding values inside rgba
+        const shadowPattern = /(?<!rgba\()\b-?\d+\b(?!\s*%\s*)(?![^(]*\))/g;
+
+        // Function to add 'px' to each matched number
+        const replaceWithPx = (match) => `${match}px`;
+
+        // Split the CSS string by ';' to handle each rule separately
+        const rules = cssString.split(";");
+
+        const processedRules = rules.map((rule) => {
+            // Split each rule into key and value by the colon
+            const [key, value] = rule.split(":");
+
+            // Check if the key includes any of the keywords
+            if (shadowKeys.some((keyword) => key.includes(keyword))) {
+                // Apply 'px' to all numeric values within the value
+                const newValue = value.replace(shadowPattern, replaceWithPx);
+                return `${key}:${newValue}`;
+            } else {
+                return rule; // Preserve rules without matching keywords
+            }
+        });
+
+        // Join the processed rules back together with semicolons
+        return processedRules.join(";").trim();
+    };
+
     convertCSSkey = (cssKey, prefix = true) => {
         const pref = prefix ? "--" : "";
         return `${pref}${cssKey.replaceAll(".", "-")}`;
@@ -305,6 +335,9 @@ class Transformer {
 
         // Convert HEX values to RGBA
         this.styleStrings.quill = this.convertHexes(this.styleStrings.quill);
+
+        // Fix Elevation values
+        this.styleStrings.quill = this.addPxToShadows(this.styleStrings.quill);
 
         // Generate Breakpoint Mixins
         this.styleStrings.breakpoints = this.generateBreakpoints();


### PR DESCRIPTION
Fixed by adding `px` on shadow related css tokens. 