### PR TITLE
Prince/downgrade version of headlessui

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.0.0-development",
             "dependencies": {
                 "@deriv/quill-icons": "^1.22.10",
-                "@headlessui/react": "^2.0.4",
+                "@headlessui/react": "^1.7.18",
                 "react-calendar": "^5.0.0",
                 "react-swipeable": "^6.2.1",
                 "react-tiny-popover": "^8.0.4",
@@ -3157,70 +3157,20 @@
             "integrity": "sha512-cEee/Z+I12mZcFJshKcCqC8tuX5hG3s+d+9nZ3LabqKF1vKdF41B92pJVCBggjAGORAeOzyyDDKrZwIkLffeOQ==",
             "dev": true
         },
-        "node_modules/@floating-ui/core": {
-            "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.2.tgz",
-            "integrity": "sha512-+2XpQV9LLZeanU4ZevzRnGFg2neDeKHgFLjP6YLW+tly0IvrhqT4u8enLGjLH3qeh85g19xY5rsAusfwTdn5lg==",
-            "dependencies": {
-                "@floating-ui/utils": "^0.2.0"
-            }
-        },
-        "node_modules/@floating-ui/dom": {
-            "version": "1.6.5",
-            "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.5.tgz",
-            "integrity": "sha512-Nsdud2X65Dz+1RHjAIP0t8z5e2ff/IRbei6BqFrl1urT8sDVzM1HMQ+R0XcU5ceRfyO3I6ayeqIfh+6Wb8LGTw==",
-            "dependencies": {
-                "@floating-ui/core": "^1.0.0",
-                "@floating-ui/utils": "^0.2.0"
-            }
-        },
-        "node_modules/@floating-ui/react": {
-            "version": "0.26.17",
-            "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.17.tgz",
-            "integrity": "sha512-ESD+jYWwqwVzaIgIhExrArdsCL1rOAzryG/Sjlu8yaD3Mtqi3uVyhbE2V7jD58Mo52qbzKz2eUY/Xgh5I86FCQ==",
-            "dependencies": {
-                "@floating-ui/react-dom": "^2.1.0",
-                "@floating-ui/utils": "^0.2.0",
-                "tabbable": "^6.0.0"
-            },
-            "peerDependencies": {
-                "react": ">=16.8.0",
-                "react-dom": ">=16.8.0"
-            }
-        },
-        "node_modules/@floating-ui/react-dom": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.0.tgz",
-            "integrity": "sha512-lNzj5EQmEKn5FFKc04+zasr09h/uX8RtJRNj5gUXsSQIXHVWTVh+hVAg1vOMCexkX8EgvemMvIFpQfkosnVNyA==",
-            "dependencies": {
-                "@floating-ui/dom": "^1.0.0"
-            },
-            "peerDependencies": {
-                "react": ">=16.8.0",
-                "react-dom": ">=16.8.0"
-            }
-        },
-        "node_modules/@floating-ui/utils": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.2.tgz",
-            "integrity": "sha512-J4yDIIthosAsRZ5CPYP/jQvUAQtlZTTD/4suA08/FEnlxqW3sKS9iAhgsa9VYLZ6vDHn/ixJgIqRQPotoBjxIw=="
-        },
         "node_modules/@headlessui/react": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-2.0.4.tgz",
-            "integrity": "sha512-16d/rOLeYsFsmPlRmXGu8DCBzrWD0zV1Ccx3n73wN87yFu8Y9+X04zflv8EJEt9TAYRyLKOmQXUnOnqQl6NgpA==",
+            "version": "1.7.19",
+            "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.19.tgz",
+            "integrity": "sha512-Ll+8q3OlMJfJbAKM/+/Y2q6PPYbryqNTXDbryx7SXLIDamkF6iQFbriYHga0dY44PvDhvvBWCx1Xj4U5+G4hOw==",
             "dependencies": {
-                "@floating-ui/react": "^0.26.13",
-                "@react-aria/focus": "^3.16.2",
-                "@react-aria/interactions": "^3.21.1",
-                "@tanstack/react-virtual": "3.5.0"
+                "@tanstack/react-virtual": "^3.0.0-beta.60",
+                "client-only": "^0.0.1"
             },
             "engines": {
                 "node": ">=10"
             },
             "peerDependencies": {
-                "react": "^18",
-                "react-dom": "^18"
+                "react": "^16 || ^17 || ^18",
+                "react-dom": "^16 || ^17 || ^18"
             }
         },
         "node_modules/@humanwhocodes/config-array": {
@@ -4731,83 +4681,6 @@
                 "@types/react": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/@react-aria/focus": {
-            "version": "3.17.1",
-            "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.17.1.tgz",
-            "integrity": "sha512-FLTySoSNqX++u0nWZJPPN5etXY0WBxaIe/YuL/GTEeuqUIuC/2bJSaw5hlsM6T2yjy6Y/VAxBcKSdAFUlU6njQ==",
-            "dependencies": {
-                "@react-aria/interactions": "^3.21.3",
-                "@react-aria/utils": "^3.24.1",
-                "@react-types/shared": "^3.23.1",
-                "@swc/helpers": "^0.5.0",
-                "clsx": "^2.0.0"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-            }
-        },
-        "node_modules/@react-aria/interactions": {
-            "version": "3.21.3",
-            "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.21.3.tgz",
-            "integrity": "sha512-BWIuf4qCs5FreDJ9AguawLVS0lV9UU+sK4CCnbCNNmYqOWY+1+gRXCsnOM32K+oMESBxilAjdHW5n1hsMqYMpA==",
-            "dependencies": {
-                "@react-aria/ssr": "^3.9.4",
-                "@react-aria/utils": "^3.24.1",
-                "@react-types/shared": "^3.23.1",
-                "@swc/helpers": "^0.5.0"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-            }
-        },
-        "node_modules/@react-aria/ssr": {
-            "version": "3.9.4",
-            "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.4.tgz",
-            "integrity": "sha512-4jmAigVq409qcJvQyuorsmBR4+9r3+JEC60wC+Y0MZV0HCtTmm8D9guYXlJMdx0SSkgj0hHAyFm/HvPNFofCoQ==",
-            "dependencies": {
-                "@swc/helpers": "^0.5.0"
-            },
-            "engines": {
-                "node": ">= 12"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-            }
-        },
-        "node_modules/@react-aria/utils": {
-            "version": "3.24.1",
-            "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.24.1.tgz",
-            "integrity": "sha512-O3s9qhPMd6n42x9sKeJ3lhu5V1Tlnzhu6Yk8QOvDuXf7UGuUjXf9mzfHJt1dYzID4l9Fwm8toczBzPM9t0jc8Q==",
-            "dependencies": {
-                "@react-aria/ssr": "^3.9.4",
-                "@react-stately/utils": "^3.10.1",
-                "@react-types/shared": "^3.23.1",
-                "@swc/helpers": "^0.5.0",
-                "clsx": "^2.0.0"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-            }
-        },
-        "node_modules/@react-stately/utils": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.10.1.tgz",
-            "integrity": "sha512-VS/EHRyicef25zDZcM/ClpzYMC5i2YGN6uegOeQawmgfGjb02yaCX0F0zR69Pod9m2Hr3wunTbtpgVXvYbZItg==",
-            "dependencies": {
-                "@swc/helpers": "^0.5.0"
-            },
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-            }
-        },
-        "node_modules/@react-types/shared": {
-            "version": "3.23.1",
-            "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.23.1.tgz",
-            "integrity": "sha512-5d+3HbFDxGZjhbMBeFHRQhexMFt4pUce3okyRtUVKbbedQFUrtXSBg9VszgF2RTeQDKDkMCIQDtz5ccP/Lk1gw==",
-            "peerDependencies": {
-                "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
             }
         },
         "node_modules/@rollup/pluginutils": {
@@ -7695,14 +7568,6 @@
                 "url": "https://opencollective.com/storybook"
             }
         },
-        "node_modules/@swc/helpers": {
-            "version": "0.5.11",
-            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.11.tgz",
-            "integrity": "sha512-YNlnKRWF2sVojTpIyzwou9XoTNbzbzONwRhOoniEioF1AtaitTvVZblaQRrAzChWQ1bLYyYSWzM18y4WwgzJ+A==",
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
         "node_modules/@tanstack/react-table": {
             "version": "8.13.2",
             "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.13.2.tgz",
@@ -10393,6 +10258,11 @@
             "funding": {
                 "url": "https://github.com/chalk/strip-ansi?sponsor=1"
             }
+        },
+        "node_modules/client-only": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+            "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
         },
         "node_modules/cliui": {
             "version": "8.0.1",
@@ -18410,7 +18280,6 @@
         },
         "node_modules/npm/node_modules/@colors/colors": {
             "version": "1.5.0",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "optional": true,
@@ -18420,7 +18289,6 @@
         },
         "node_modules/npm/node_modules/@isaacs/cliui": {
             "version": "8.0.2",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -18437,7 +18305,6 @@
         },
         "node_modules/npm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
             "version": "6.0.1",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -18449,13 +18316,11 @@
         },
         "node_modules/npm/node_modules/@isaacs/cliui/node_modules/emoji-regex": {
             "version": "9.2.2",
-            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/@isaacs/cliui/node_modules/string-width": {
             "version": "5.1.2",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -18472,7 +18337,6 @@
         },
         "node_modules/npm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
             "version": "7.1.0",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -18487,13 +18351,11 @@
         },
         "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
             "version": "1.1.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/npm/node_modules/@npmcli/agent": {
             "version": "2.2.1",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -18509,7 +18371,6 @@
         },
         "node_modules/npm/node_modules/@npmcli/arborist": {
             "version": "7.4.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -18556,7 +18417,6 @@
         },
         "node_modules/npm/node_modules/@npmcli/config": {
             "version": "8.2.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -18575,7 +18435,6 @@
         },
         "node_modules/npm/node_modules/@npmcli/disparity-colors": {
             "version": "3.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -18587,7 +18446,6 @@
         },
         "node_modules/npm/node_modules/@npmcli/disparity-colors/node_modules/ansi-styles": {
             "version": "4.3.0",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -18602,7 +18460,6 @@
         },
         "node_modules/npm/node_modules/@npmcli/fs": {
             "version": "3.1.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -18614,7 +18471,6 @@
         },
         "node_modules/npm/node_modules/@npmcli/git": {
             "version": "5.0.4",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -18633,7 +18489,6 @@
         },
         "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
             "version": "2.0.2",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -18649,7 +18504,6 @@
         },
         "node_modules/npm/node_modules/@npmcli/map-workspaces": {
             "version": "3.0.4",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -18664,7 +18518,6 @@
         },
         "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
             "version": "7.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -18679,7 +18532,6 @@
         },
         "node_modules/npm/node_modules/@npmcli/name-from-folder": {
             "version": "2.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -18688,7 +18540,6 @@
         },
         "node_modules/npm/node_modules/@npmcli/node-gyp": {
             "version": "3.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -18697,7 +18548,6 @@
         },
         "node_modules/npm/node_modules/@npmcli/package-json": {
             "version": "5.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -18715,7 +18565,6 @@
         },
         "node_modules/npm/node_modules/@npmcli/promise-spawn": {
             "version": "7.0.1",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -18727,7 +18576,6 @@
         },
         "node_modules/npm/node_modules/@npmcli/query": {
             "version": "3.1.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -18739,7 +18587,6 @@
         },
         "node_modules/npm/node_modules/@npmcli/run-script": {
             "version": "7.0.4",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -18755,7 +18602,6 @@
         },
         "node_modules/npm/node_modules/@pkgjs/parseargs": {
             "version": "0.11.0",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "optional": true,
@@ -18765,7 +18611,6 @@
         },
         "node_modules/npm/node_modules/@sigstore/bundle": {
             "version": "2.2.0",
-            "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -18777,7 +18622,6 @@
         },
         "node_modules/npm/node_modules/@sigstore/core": {
             "version": "1.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
             "engines": {
@@ -18786,7 +18630,6 @@
         },
         "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
             "version": "0.3.0",
-            "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
             "engines": {
@@ -18795,7 +18638,6 @@
         },
         "node_modules/npm/node_modules/@sigstore/sign": {
             "version": "2.2.3",
-            "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -18810,7 +18652,6 @@
         },
         "node_modules/npm/node_modules/@sigstore/tuf": {
             "version": "2.3.1",
-            "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -18823,7 +18664,6 @@
         },
         "node_modules/npm/node_modules/@sigstore/verify": {
             "version": "1.1.0",
-            "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -18837,7 +18677,6 @@
         },
         "node_modules/npm/node_modules/@tufjs/canonical-json": {
             "version": "2.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -18846,7 +18685,6 @@
         },
         "node_modules/npm/node_modules/@tufjs/models": {
             "version": "2.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -18859,7 +18697,6 @@
         },
         "node_modules/npm/node_modules/abbrev": {
             "version": "2.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -18868,7 +18705,6 @@
         },
         "node_modules/npm/node_modules/agent-base": {
             "version": "7.1.0",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -18880,7 +18716,6 @@
         },
         "node_modules/npm/node_modules/aggregate-error": {
             "version": "3.1.0",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -18893,7 +18728,6 @@
         },
         "node_modules/npm/node_modules/ansi-regex": {
             "version": "5.0.1",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -18902,7 +18736,6 @@
         },
         "node_modules/npm/node_modules/ansi-styles": {
             "version": "6.2.1",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -18914,19 +18747,16 @@
         },
         "node_modules/npm/node_modules/aproba": {
             "version": "2.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/npm/node_modules/archy": {
             "version": "1.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/are-we-there-yet": {
             "version": "4.0.2",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -18935,13 +18765,11 @@
         },
         "node_modules/npm/node_modules/balanced-match": {
             "version": "1.0.2",
-            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/bin-links": {
             "version": "4.0.3",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -18956,7 +18784,6 @@
         },
         "node_modules/npm/node_modules/binary-extensions": {
             "version": "2.2.0",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -18965,7 +18792,6 @@
         },
         "node_modules/npm/node_modules/brace-expansion": {
             "version": "2.0.1",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -18974,7 +18800,6 @@
         },
         "node_modules/npm/node_modules/builtins": {
             "version": "5.0.1",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -18983,7 +18808,6 @@
         },
         "node_modules/npm/node_modules/cacache": {
             "version": "18.0.2",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -19006,7 +18830,6 @@
         },
         "node_modules/npm/node_modules/chalk": {
             "version": "5.3.0",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -19018,7 +18841,6 @@
         },
         "node_modules/npm/node_modules/chownr": {
             "version": "2.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -19027,7 +18849,6 @@
         },
         "node_modules/npm/node_modules/ci-info": {
             "version": "4.0.0",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -19042,7 +18863,6 @@
         },
         "node_modules/npm/node_modules/cidr-regex": {
             "version": "4.0.3",
-            "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -19054,7 +18874,6 @@
         },
         "node_modules/npm/node_modules/clean-stack": {
             "version": "2.2.0",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -19063,7 +18882,6 @@
         },
         "node_modules/npm/node_modules/cli-columns": {
             "version": "4.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -19076,7 +18894,6 @@
         },
         "node_modules/npm/node_modules/cli-table3": {
             "version": "0.6.3",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -19091,7 +18908,6 @@
         },
         "node_modules/npm/node_modules/clone": {
             "version": "1.0.4",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -19100,7 +18916,6 @@
         },
         "node_modules/npm/node_modules/cmd-shim": {
             "version": "6.0.2",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -19109,7 +18924,6 @@
         },
         "node_modules/npm/node_modules/color-convert": {
             "version": "2.0.1",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -19121,13 +18935,11 @@
         },
         "node_modules/npm/node_modules/color-name": {
             "version": "1.1.4",
-            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/color-support": {
             "version": "1.1.3",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "bin": {
@@ -19136,7 +18948,6 @@
         },
         "node_modules/npm/node_modules/columnify": {
             "version": "1.6.0",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -19149,19 +18960,16 @@
         },
         "node_modules/npm/node_modules/common-ancestor-path": {
             "version": "1.0.1",
-            "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/npm/node_modules/console-control-strings": {
             "version": "1.1.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/npm/node_modules/cross-spawn": {
             "version": "7.0.3",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -19175,7 +18983,6 @@
         },
         "node_modules/npm/node_modules/cross-spawn/node_modules/which": {
             "version": "2.0.2",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -19190,7 +18997,6 @@
         },
         "node_modules/npm/node_modules/cssesc": {
             "version": "3.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "bin": {
@@ -19202,7 +19008,6 @@
         },
         "node_modules/npm/node_modules/debug": {
             "version": "4.3.4",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -19219,13 +19024,11 @@
         },
         "node_modules/npm/node_modules/debug/node_modules/ms": {
             "version": "2.1.2",
-            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/defaults": {
             "version": "1.0.4",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -19237,7 +19040,6 @@
         },
         "node_modules/npm/node_modules/diff": {
             "version": "5.2.0",
-            "dev": true,
             "inBundle": true,
             "license": "BSD-3-Clause",
             "engines": {
@@ -19246,19 +19048,16 @@
         },
         "node_modules/npm/node_modules/eastasianwidth": {
             "version": "0.2.0",
-            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/emoji-regex": {
             "version": "8.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/encoding": {
             "version": "0.1.13",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "optional": true,
@@ -19268,7 +19067,6 @@
         },
         "node_modules/npm/node_modules/env-paths": {
             "version": "2.2.1",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -19277,19 +19075,16 @@
         },
         "node_modules/npm/node_modules/err-code": {
             "version": "2.0.3",
-            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/exponential-backoff": {
             "version": "3.1.1",
-            "dev": true,
             "inBundle": true,
             "license": "Apache-2.0"
         },
         "node_modules/npm/node_modules/fastest-levenshtein": {
             "version": "1.0.16",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -19298,7 +19093,6 @@
         },
         "node_modules/npm/node_modules/foreground-child": {
             "version": "3.1.1",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -19314,7 +19108,6 @@
         },
         "node_modules/npm/node_modules/fs-minipass": {
             "version": "3.0.3",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -19326,7 +19119,6 @@
         },
         "node_modules/npm/node_modules/function-bind": {
             "version": "1.1.2",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "funding": {
@@ -19335,7 +19127,6 @@
         },
         "node_modules/npm/node_modules/gauge": {
             "version": "5.0.1",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -19354,7 +19145,6 @@
         },
         "node_modules/npm/node_modules/glob": {
             "version": "10.3.10",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -19376,19 +19166,16 @@
         },
         "node_modules/npm/node_modules/graceful-fs": {
             "version": "4.2.11",
-            "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/npm/node_modules/has-unicode": {
             "version": "2.0.1",
-            "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/npm/node_modules/hasown": {
             "version": "2.0.1",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -19400,7 +19187,6 @@
         },
         "node_modules/npm/node_modules/hosted-git-info": {
             "version": "7.0.1",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -19412,13 +19198,11 @@
         },
         "node_modules/npm/node_modules/http-cache-semantics": {
             "version": "4.1.1",
-            "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause"
         },
         "node_modules/npm/node_modules/http-proxy-agent": {
             "version": "7.0.2",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -19431,7 +19215,6 @@
         },
         "node_modules/npm/node_modules/https-proxy-agent": {
             "version": "7.0.4",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -19444,7 +19227,6 @@
         },
         "node_modules/npm/node_modules/iconv-lite": {
             "version": "0.6.3",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "optional": true,
@@ -19457,7 +19239,6 @@
         },
         "node_modules/npm/node_modules/ignore-walk": {
             "version": "6.0.4",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -19469,7 +19250,6 @@
         },
         "node_modules/npm/node_modules/imurmurhash": {
             "version": "0.1.4",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -19478,7 +19258,6 @@
         },
         "node_modules/npm/node_modules/indent-string": {
             "version": "4.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -19487,7 +19266,6 @@
         },
         "node_modules/npm/node_modules/ini": {
             "version": "4.1.1",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -19496,7 +19274,6 @@
         },
         "node_modules/npm/node_modules/init-package-json": {
             "version": "6.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -19514,7 +19291,6 @@
         },
         "node_modules/npm/node_modules/ip-address": {
             "version": "9.0.5",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -19527,13 +19303,11 @@
         },
         "node_modules/npm/node_modules/ip-address/node_modules/sprintf-js": {
             "version": "1.1.3",
-            "dev": true,
             "inBundle": true,
             "license": "BSD-3-Clause"
         },
         "node_modules/npm/node_modules/ip-regex": {
             "version": "5.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -19545,7 +19319,6 @@
         },
         "node_modules/npm/node_modules/is-cidr": {
             "version": "5.0.3",
-            "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -19557,7 +19330,6 @@
         },
         "node_modules/npm/node_modules/is-core-module": {
             "version": "2.13.1",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -19569,7 +19341,6 @@
         },
         "node_modules/npm/node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -19578,19 +19349,16 @@
         },
         "node_modules/npm/node_modules/is-lambda": {
             "version": "1.0.1",
-            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/isexe": {
             "version": "2.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/npm/node_modules/jackspeak": {
             "version": "2.3.6",
-            "dev": true,
             "inBundle": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
@@ -19608,13 +19376,11 @@
         },
         "node_modules/npm/node_modules/jsbn": {
             "version": "1.1.0",
-            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/json-parse-even-better-errors": {
             "version": "3.0.1",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -19623,7 +19389,6 @@
         },
         "node_modules/npm/node_modules/json-stringify-nice": {
             "version": "1.1.4",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "funding": {
@@ -19632,7 +19397,6 @@
         },
         "node_modules/npm/node_modules/jsonparse": {
             "version": "1.3.1",
-            "dev": true,
             "engines": [
                 "node >= 0.2.0"
             ],
@@ -19641,19 +19405,16 @@
         },
         "node_modules/npm/node_modules/just-diff": {
             "version": "6.0.2",
-            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/just-diff-apply": {
             "version": "5.5.0",
-            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/libnpmaccess": {
             "version": "8.0.2",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -19666,7 +19427,6 @@
         },
         "node_modules/npm/node_modules/libnpmdiff": {
             "version": "6.0.7",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -19686,7 +19446,6 @@
         },
         "node_modules/npm/node_modules/libnpmexec": {
             "version": "7.0.8",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -19708,7 +19467,6 @@
         },
         "node_modules/npm/node_modules/libnpmfund": {
             "version": "5.0.5",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -19720,7 +19478,6 @@
         },
         "node_modules/npm/node_modules/libnpmhook": {
             "version": "10.0.1",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -19733,7 +19490,6 @@
         },
         "node_modules/npm/node_modules/libnpmorg": {
             "version": "6.0.2",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -19746,7 +19502,6 @@
         },
         "node_modules/npm/node_modules/libnpmpack": {
             "version": "6.0.7",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -19761,7 +19516,6 @@
         },
         "node_modules/npm/node_modules/libnpmpublish": {
             "version": "9.0.4",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -19780,7 +19534,6 @@
         },
         "node_modules/npm/node_modules/libnpmsearch": {
             "version": "7.0.1",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -19792,7 +19545,6 @@
         },
         "node_modules/npm/node_modules/libnpmteam": {
             "version": "6.0.1",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -19805,7 +19557,6 @@
         },
         "node_modules/npm/node_modules/libnpmversion": {
             "version": "5.0.2",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -19821,7 +19572,6 @@
         },
         "node_modules/npm/node_modules/lru-cache": {
             "version": "10.2.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -19830,7 +19580,6 @@
         },
         "node_modules/npm/node_modules/make-fetch-happen": {
             "version": "13.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -19852,7 +19601,6 @@
         },
         "node_modules/npm/node_modules/minimatch": {
             "version": "9.0.3",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -19867,7 +19615,6 @@
         },
         "node_modules/npm/node_modules/minipass": {
             "version": "7.0.4",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -19876,7 +19623,6 @@
         },
         "node_modules/npm/node_modules/minipass-collect": {
             "version": "2.0.1",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -19888,7 +19634,6 @@
         },
         "node_modules/npm/node_modules/minipass-fetch": {
             "version": "3.0.4",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -19905,7 +19650,6 @@
         },
         "node_modules/npm/node_modules/minipass-flush": {
             "version": "1.0.5",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -19917,7 +19661,6 @@
         },
         "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
             "version": "3.3.6",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -19929,7 +19672,6 @@
         },
         "node_modules/npm/node_modules/minipass-json-stream": {
             "version": "1.0.1",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -19939,7 +19681,6 @@
         },
         "node_modules/npm/node_modules/minipass-json-stream/node_modules/minipass": {
             "version": "3.3.6",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -19951,7 +19692,6 @@
         },
         "node_modules/npm/node_modules/minipass-pipeline": {
             "version": "1.2.4",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -19963,7 +19703,6 @@
         },
         "node_modules/npm/node_modules/minipass-pipeline/node_modules/minipass": {
             "version": "3.3.6",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -19975,7 +19714,6 @@
         },
         "node_modules/npm/node_modules/minipass-sized": {
             "version": "1.0.3",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -19987,7 +19725,6 @@
         },
         "node_modules/npm/node_modules/minipass-sized/node_modules/minipass": {
             "version": "3.3.6",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -19999,7 +19736,6 @@
         },
         "node_modules/npm/node_modules/minizlib": {
             "version": "2.1.2",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -20012,7 +19748,6 @@
         },
         "node_modules/npm/node_modules/minizlib/node_modules/minipass": {
             "version": "3.3.6",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -20024,7 +19759,6 @@
         },
         "node_modules/npm/node_modules/mkdirp": {
             "version": "1.0.4",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "bin": {
@@ -20036,13 +19770,11 @@
         },
         "node_modules/npm/node_modules/ms": {
             "version": "2.1.3",
-            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/mute-stream": {
             "version": "1.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -20051,7 +19783,6 @@
         },
         "node_modules/npm/node_modules/negotiator": {
             "version": "0.6.3",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -20060,7 +19791,6 @@
         },
         "node_modules/npm/node_modules/node-gyp": {
             "version": "10.0.1",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -20084,7 +19814,6 @@
         },
         "node_modules/npm/node_modules/nopt": {
             "version": "7.2.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -20099,7 +19828,6 @@
         },
         "node_modules/npm/node_modules/normalize-package-data": {
             "version": "6.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -20114,7 +19842,6 @@
         },
         "node_modules/npm/node_modules/npm-audit-report": {
             "version": "5.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -20123,7 +19850,6 @@
         },
         "node_modules/npm/node_modules/npm-bundled": {
             "version": "3.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -20135,7 +19861,6 @@
         },
         "node_modules/npm/node_modules/npm-install-checks": {
             "version": "6.3.0",
-            "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -20147,7 +19872,6 @@
         },
         "node_modules/npm/node_modules/npm-normalize-package-bin": {
             "version": "3.0.1",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -20156,7 +19880,6 @@
         },
         "node_modules/npm/node_modules/npm-package-arg": {
             "version": "11.0.1",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -20171,7 +19894,6 @@
         },
         "node_modules/npm/node_modules/npm-packlist": {
             "version": "8.0.2",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -20183,7 +19905,6 @@
         },
         "node_modules/npm/node_modules/npm-pick-manifest": {
             "version": "9.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -20198,7 +19919,6 @@
         },
         "node_modules/npm/node_modules/npm-profile": {
             "version": "9.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -20211,7 +19931,6 @@
         },
         "node_modules/npm/node_modules/npm-registry-fetch": {
             "version": "16.1.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -20229,7 +19948,6 @@
         },
         "node_modules/npm/node_modules/npm-user-validate": {
             "version": "2.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "BSD-2-Clause",
             "engines": {
@@ -20238,7 +19956,6 @@
         },
         "node_modules/npm/node_modules/npmlog": {
             "version": "7.0.1",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -20253,7 +19970,6 @@
         },
         "node_modules/npm/node_modules/p-map": {
             "version": "4.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -20268,7 +19984,6 @@
         },
         "node_modules/npm/node_modules/pacote": {
             "version": "17.0.6",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -20300,7 +20015,6 @@
         },
         "node_modules/npm/node_modules/parse-conflict-json": {
             "version": "3.0.1",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -20314,7 +20028,6 @@
         },
         "node_modules/npm/node_modules/path-key": {
             "version": "3.1.1",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -20323,7 +20036,6 @@
         },
         "node_modules/npm/node_modules/path-scurry": {
             "version": "1.10.1",
-            "dev": true,
             "inBundle": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
@@ -20339,7 +20051,6 @@
         },
         "node_modules/npm/node_modules/postcss-selector-parser": {
             "version": "6.0.15",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -20352,7 +20063,6 @@
         },
         "node_modules/npm/node_modules/proc-log": {
             "version": "3.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -20361,7 +20071,6 @@
         },
         "node_modules/npm/node_modules/promise-all-reject-late": {
             "version": "1.0.1",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "funding": {
@@ -20370,7 +20079,6 @@
         },
         "node_modules/npm/node_modules/promise-call-limit": {
             "version": "3.0.1",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "funding": {
@@ -20379,13 +20087,11 @@
         },
         "node_modules/npm/node_modules/promise-inflight": {
             "version": "1.0.1",
-            "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/npm/node_modules/promise-retry": {
             "version": "2.0.1",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -20398,7 +20104,6 @@
         },
         "node_modules/npm/node_modules/promzard": {
             "version": "1.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -20410,7 +20115,6 @@
         },
         "node_modules/npm/node_modules/qrcode-terminal": {
             "version": "0.12.0",
-            "dev": true,
             "inBundle": true,
             "bin": {
                 "qrcode-terminal": "bin/qrcode-terminal.js"
@@ -20418,7 +20122,6 @@
         },
         "node_modules/npm/node_modules/read": {
             "version": "2.1.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -20430,7 +20133,6 @@
         },
         "node_modules/npm/node_modules/read-cmd-shim": {
             "version": "4.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -20439,7 +20141,6 @@
         },
         "node_modules/npm/node_modules/read-package-json": {
             "version": "7.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -20454,7 +20155,6 @@
         },
         "node_modules/npm/node_modules/read-package-json-fast": {
             "version": "3.0.2",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -20467,7 +20167,6 @@
         },
         "node_modules/npm/node_modules/retry": {
             "version": "0.12.0",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -20476,14 +20175,12 @@
         },
         "node_modules/npm/node_modules/safer-buffer": {
             "version": "2.1.2",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "optional": true
         },
         "node_modules/npm/node_modules/semver": {
             "version": "7.6.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -20498,7 +20195,6 @@
         },
         "node_modules/npm/node_modules/semver/node_modules/lru-cache": {
             "version": "6.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -20510,13 +20206,11 @@
         },
         "node_modules/npm/node_modules/set-blocking": {
             "version": "2.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/npm/node_modules/shebang-command": {
             "version": "2.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -20528,7 +20222,6 @@
         },
         "node_modules/npm/node_modules/shebang-regex": {
             "version": "3.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -20537,7 +20230,6 @@
         },
         "node_modules/npm/node_modules/signal-exit": {
             "version": "4.1.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -20549,7 +20241,6 @@
         },
         "node_modules/npm/node_modules/sigstore": {
             "version": "2.2.2",
-            "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -20566,7 +20257,6 @@
         },
         "node_modules/npm/node_modules/smart-buffer": {
             "version": "4.2.0",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -20576,7 +20266,6 @@
         },
         "node_modules/npm/node_modules/socks": {
             "version": "2.8.0",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -20590,7 +20279,6 @@
         },
         "node_modules/npm/node_modules/socks-proxy-agent": {
             "version": "8.0.2",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -20604,7 +20292,6 @@
         },
         "node_modules/npm/node_modules/spdx-correct": {
             "version": "3.2.0",
-            "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -20614,13 +20301,11 @@
         },
         "node_modules/npm/node_modules/spdx-exceptions": {
             "version": "2.5.0",
-            "dev": true,
             "inBundle": true,
             "license": "CC-BY-3.0"
         },
         "node_modules/npm/node_modules/spdx-expression-parse": {
             "version": "3.0.1",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -20630,13 +20315,11 @@
         },
         "node_modules/npm/node_modules/spdx-license-ids": {
             "version": "3.0.17",
-            "dev": true,
             "inBundle": true,
             "license": "CC0-1.0"
         },
         "node_modules/npm/node_modules/ssri": {
             "version": "10.0.5",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -20648,7 +20331,6 @@
         },
         "node_modules/npm/node_modules/string-width": {
             "version": "4.2.3",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -20663,7 +20345,6 @@
         "node_modules/npm/node_modules/string-width-cjs": {
             "name": "string-width",
             "version": "4.2.3",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -20677,7 +20358,6 @@
         },
         "node_modules/npm/node_modules/strip-ansi": {
             "version": "6.0.1",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -20690,7 +20370,6 @@
         "node_modules/npm/node_modules/strip-ansi-cjs": {
             "name": "strip-ansi",
             "version": "6.0.1",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -20702,7 +20381,6 @@
         },
         "node_modules/npm/node_modules/supports-color": {
             "version": "9.4.0",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -20714,7 +20392,6 @@
         },
         "node_modules/npm/node_modules/tar": {
             "version": "6.2.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -20731,7 +20408,6 @@
         },
         "node_modules/npm/node_modules/tar/node_modules/fs-minipass": {
             "version": "2.1.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -20743,7 +20419,6 @@
         },
         "node_modules/npm/node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
             "version": "3.3.6",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -20755,7 +20430,6 @@
         },
         "node_modules/npm/node_modules/tar/node_modules/minipass": {
             "version": "5.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -20764,19 +20438,16 @@
         },
         "node_modules/npm/node_modules/text-table": {
             "version": "0.2.0",
-            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/tiny-relative-date": {
             "version": "1.3.0",
-            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/treeverse": {
             "version": "3.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -20785,7 +20456,6 @@
         },
         "node_modules/npm/node_modules/tuf-js": {
             "version": "2.2.0",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -20799,7 +20469,6 @@
         },
         "node_modules/npm/node_modules/unique-filename": {
             "version": "3.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -20811,7 +20480,6 @@
         },
         "node_modules/npm/node_modules/unique-slug": {
             "version": "4.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -20823,13 +20491,11 @@
         },
         "node_modules/npm/node_modules/util-deprecate": {
             "version": "1.0.2",
-            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/validate-npm-package-license": {
             "version": "3.0.4",
-            "dev": true,
             "inBundle": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -20839,7 +20505,6 @@
         },
         "node_modules/npm/node_modules/validate-npm-package-name": {
             "version": "5.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -20851,13 +20516,11 @@
         },
         "node_modules/npm/node_modules/walk-up-path": {
             "version": "3.0.1",
-            "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
         "node_modules/npm/node_modules/wcwidth": {
             "version": "1.0.1",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -20866,7 +20529,6 @@
         },
         "node_modules/npm/node_modules/which": {
             "version": "4.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -20881,7 +20543,6 @@
         },
         "node_modules/npm/node_modules/which/node_modules/isexe": {
             "version": "3.1.1",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "engines": {
@@ -20890,7 +20551,6 @@
         },
         "node_modules/npm/node_modules/wide-align": {
             "version": "1.1.5",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -20899,7 +20559,6 @@
         },
         "node_modules/npm/node_modules/wrap-ansi": {
             "version": "8.1.0",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -20917,7 +20576,6 @@
         "node_modules/npm/node_modules/wrap-ansi-cjs": {
             "name": "wrap-ansi",
             "version": "7.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -20934,7 +20592,6 @@
         },
         "node_modules/npm/node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
             "version": "4.3.0",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -20949,7 +20606,6 @@
         },
         "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
             "version": "6.0.1",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -20961,13 +20617,11 @@
         },
         "node_modules/npm/node_modules/wrap-ansi/node_modules/emoji-regex": {
             "version": "9.2.2",
-            "dev": true,
             "inBundle": true,
             "license": "MIT"
         },
         "node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
             "version": "5.1.2",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -20984,7 +20638,6 @@
         },
         "node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
             "version": "7.1.0",
-            "dev": true,
             "inBundle": true,
             "license": "MIT",
             "dependencies": {
@@ -20999,7 +20652,6 @@
         },
         "node_modules/npm/node_modules/write-file-atomic": {
             "version": "5.0.1",
-            "dev": true,
             "inBundle": true,
             "license": "ISC",
             "dependencies": {
@@ -21012,7 +20664,6 @@
         },
         "node_modules/npm/node_modules/yallist": {
             "version": "4.0.0",
-            "dev": true,
             "inBundle": true,
             "license": "ISC"
         },
@@ -24176,11 +23827,6 @@
             "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
             "dev": true
         },
-        "node_modules/tabbable": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-            "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
-        },
         "node_modules/tapable": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
@@ -24817,7 +24463,8 @@
         "node_modules/tslib": {
             "version": "2.6.3",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-            "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+            "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+            "dev": true
         },
         "node_modules/tsutils": {
             "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     },
     "dependencies": {
         "@deriv/quill-icons": "^1.22.10",
-        "@headlessui/react": "^2.0.4",
+        "@headlessui/react": "^1.7.18",
         "react-calendar": "^5.0.0",
         "react-swipeable": "^6.2.1",
         "react-tiny-popover": "^8.0.4",


### PR DESCRIPTION
For deriv-app compatibility we needed to lock the version of `headlessui/react` 