### PR TITLE
Meenu/fix: fixed color for status msg

### DIFF
--- a/lib/components/Atom/PasswordValidation/index.tsx
+++ b/lib/components/Atom/PasswordValidation/index.tsx
@@ -21,7 +21,9 @@ export const PasswordStrengthValidation = ({
             ) : (
                 <LabelPairedCircleCaptionRegularIcon fill="var(--component-textIcon-normal-default)" />
             )}
-            <CaptionText color={status}>{validationMessage}</CaptionText>
+            <CaptionText className={`validation_message__status--${status}`}>
+                {validationMessage}
+            </CaptionText>
         </div>
     );
 };

--- a/lib/components/Atom/PasswordValidation/password-validation.scss
+++ b/lib/components/Atom/PasswordValidation/password-validation.scss
@@ -2,4 +2,17 @@
     display: flex;
     flex-direction: row;
     gap: var(--semantic-spacing-gap-md);
+   
+    &__status {
+
+        &--neutral {
+            color: var(--component-field-label-color-default);
+        }
+        &--success {
+            color: var(--component-field-label-color-success);
+        }
+        &--error {
+            color: var(--component-field-label-color-fail);
+        }
+    }
 }


### PR DESCRIPTION
Fix for status message color 

<img width="379" alt="Screenshot 2024-06-25 at 10 39 46 AM" src="https://github.com/deriv-com/quill-ui/assets/104189801/fbcb72fb-68f8-4e88-aee9-856bc5870e47">
