### PR TITLE
Maryai/fix: hooks rendering issue in SegmentedControlSingleChoice upon options prop update

### DIFF
--- a/lib/components/SegmentedControl/base.tsx
+++ b/lib/components/SegmentedControl/base.tsx
@@ -7,7 +7,7 @@ import React, {
 } from "react";
 import { TRegularSizes } from "@types";
 import { KEY } from "@utils/common-utils";
-import { Segment } from "./segment";
+import { Segments } from "./segments";
 import "./segmented-control.scss";
 
 interface Option {
@@ -95,35 +95,28 @@ export const SegmentedControl = ({
 
     return (
         <div className={className}>
-            {options.map(({ disabled, icon, label, selected }, idx) => {
-                const segmentRef = React.useRef<HTMLButtonElement>(null);
-
-                return (
-                    <Segment
-                        allowFocus={allowFocus}
-                        key={`${idx}_${label}`}
-                        icon={icon}
-                        isAnimated={
-                            selected &&
-                            animatedOptionIdx === idx &&
-                            hasAnimation
-                        }
-                        isDisabled={disabled}
-                        isSelected={selected}
-                        label={label}
-                        onClick={() => {
-                            animate(idx, segmentRef);
-                            onChange?.(idx);
-                            setAllowFocus(false);
-                        }}
-                        onKeyDown={(
-                            e: React.KeyboardEvent<HTMLButtonElement>,
-                        ) => handleKeyboardEvents(e, idx)}
-                        size={size}
-                        ref={selected ? selectedRef : segmentRef}
-                    />
-                );
-            })}
+            {options.map((item, idx) => (
+                <Segments
+                    key={idx}
+                    allowFocus={allowFocus}
+                    animatedOptionIdx={animatedOptionIdx}
+                    hasAnimation={hasAnimation}
+                    idx={idx}
+                    onClick={(
+                        segmentRef: React.RefObject<HTMLButtonElement>,
+                    ) => {
+                        animate(idx, segmentRef);
+                        onChange?.(idx);
+                        setAllowFocus(false);
+                    }}
+                    onKeyDown={(e: React.KeyboardEvent<HTMLButtonElement>) =>
+                        handleKeyboardEvents(e, idx)
+                    }
+                    selectedRef={selectedRef}
+                    size={size}
+                    {...item}
+                />
+            ))}
         </div>
     );
 };

--- a/lib/components/SegmentedControl/base.tsx
+++ b/lib/components/SegmentedControl/base.tsx
@@ -99,9 +99,11 @@ export const SegmentedControl = ({
                 <Segments
                     key={idx}
                     allowFocus={allowFocus}
-                    animatedOptionIdx={animatedOptionIdx}
-                    hasAnimation={hasAnimation}
-                    idx={idx}
+                    isAnimated={
+                        item.selected &&
+                        animatedOptionIdx === idx &&
+                        hasAnimation
+                    }
                     onClick={(
                         segmentRef: React.RefObject<HTMLButtonElement>,
                     ) => {

--- a/lib/components/SegmentedControl/segment.tsx
+++ b/lib/components/SegmentedControl/segment.tsx
@@ -4,7 +4,7 @@ import { Text } from "@components/Typography";
 import { KEY } from "@utils/common-utils";
 import { SegmentedControlProps } from "./base";
 
-interface SegmentProps {
+export interface SegmentProps {
     allowFocus?: boolean;
     className?: string;
     icon?: ReactNode;

--- a/lib/components/SegmentedControl/segments.tsx
+++ b/lib/components/SegmentedControl/segments.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { Segment, SegmentProps } from "./segment";
+
+interface SegmentsProps extends Omit<SegmentProps, "onClick"> {
+    animatedOptionIdx: number | null;
+    hasAnimation?: boolean;
+    disabled?: SegmentProps["isDisabled"];
+    idx: number;
+    onClick: (ref: React.RefObject<HTMLButtonElement>) => void;
+    selected?: SegmentProps["isSelected"];
+    selectedRef: React.RefObject<HTMLButtonElement>;
+}
+
+export const Segments = ({
+    animatedOptionIdx,
+    hasAnimation,
+    disabled,
+    idx,
+    onClick,
+    selected,
+    selectedRef,
+    ...rest
+}: SegmentsProps) => {
+    const segmentRef = React.useRef<HTMLButtonElement>(null);
+
+    return (
+        <Segment
+            isAnimated={selected && animatedOptionIdx === idx && hasAnimation}
+            isDisabled={disabled}
+            isSelected={selected}
+            onClick={() => onClick(segmentRef)}
+            ref={selected ? selectedRef : segmentRef}
+            {...rest}
+        />
+    );
+};

--- a/lib/components/SegmentedControl/segments.tsx
+++ b/lib/components/SegmentedControl/segments.tsx
@@ -2,20 +2,14 @@ import React from "react";
 import { Segment, SegmentProps } from "./segment";
 
 interface SegmentsProps extends Omit<SegmentProps, "onClick"> {
-    animatedOptionIdx: number | null;
-    hasAnimation?: boolean;
     disabled?: SegmentProps["isDisabled"];
-    idx: number;
     onClick: (ref: React.RefObject<HTMLButtonElement>) => void;
     selected?: SegmentProps["isSelected"];
     selectedRef: React.RefObject<HTMLButtonElement>;
 }
 
 export const Segments = ({
-    animatedOptionIdx,
-    hasAnimation,
     disabled,
-    idx,
     onClick,
     selected,
     selectedRef,
@@ -25,7 +19,6 @@ export const Segments = ({
 
     return (
         <Segment
-            isAnimated={selected && animatedOptionIdx === idx && hasAnimation}
             isDisabled={disabled}
             isSelected={selected}
             onClick={() => onClick(segmentRef)}


### PR DESCRIPTION
- to fix hooks rendering issue in SegmentedControlSingleChoice upon options prop update by isolating mapped Segments with their own ref into a separate component.