### PR TITLE
DTRA-1415 / Kate / Refactor: action sheet component

### DIFF
--- a/lib/components/ActionSheet/button-trigger.stories.tsx
+++ b/lib/components/ActionSheet/button-trigger.stories.tsx
@@ -45,6 +45,20 @@ const meta: Meta = {
             description:
                 "This prop controls if action sheet should be closed on drag down or not. Default value: false. Property should be passed to ActionSheet.Portal",
         },
+        shouldDetectSwipingOnContainer: {
+            table: { type: { summary: "boolean | undefined" } },
+            options: ["true", "false"],
+            control: { type: "boolean" },
+            description:
+                "This prop controls if swiping will be detected on the whole Action Sheet, not only on Handlebar. Default value: false. Property should be passed to ActionSheet.Portal",
+        },
+        showHandlebar: {
+            table: { type: { summary: "boolean | undefined" } },
+            options: ["true", "false"],
+            control: { type: "boolean" },
+            description:
+                "This prop controls if Handlebar should be visible or not. Default value: true",
+        },
         fullHeightOnOpen: {
             description:
                 "This props controls is full height when open the actionsheet",

--- a/lib/components/ActionSheet/controlled.stories.tsx
+++ b/lib/components/ActionSheet/controlled.stories.tsx
@@ -56,6 +56,20 @@ const meta: Meta = {
             description:
                 "This prop controls if action sheet should be closed on drag down or not. Default value: false. Property should be passed to ActionSheet.Portal",
         },
+        shouldDetectSwipingOnContainer: {
+            table: { type: { summary: "boolean | undefined" } },
+            options: ["true", "false"],
+            control: { type: "boolean" },
+            description:
+                "This prop controls if swiping will be detected on the whole Action Sheet, not only on Handlebar. Default value: false. Property should be passed to ActionSheet.Portal",
+        },
+        showHandlebar: {
+            table: { type: { summary: "boolean | undefined" } },
+            options: ["true", "false"],
+            control: { type: "boolean" },
+            description:
+                "This prop controls if Handlebar should be visible or not. Default value: true",
+        },
         fullHeightOnOpen: {
             description:
                 "This props controls is full height when open the actionsheet",

--- a/lib/components/ActionSheet/icon-trigger.stories.tsx
+++ b/lib/components/ActionSheet/icon-trigger.stories.tsx
@@ -51,6 +51,20 @@ const meta: Meta = {
             description:
                 "This prop controls if action sheet should be closed on drag down or not. Default value: false. Property should be passed to ActionSheet.Portal",
         },
+        shouldDetectSwipingOnContainer: {
+            table: { type: { summary: "boolean | undefined" } },
+            options: ["true", "false"],
+            control: { type: "boolean" },
+            description:
+                "This prop controls if swiping will be detected on the whole Action Sheet, not only on Handlebar. Default value: false. Property should be passed to ActionSheet.Portal",
+        },
+        showHandlebar: {
+            table: { type: { summary: "boolean | undefined" } },
+            options: ["true", "false"],
+            control: { type: "boolean" },
+            description:
+                "This prop controls if Handlebar should be visible or not. Default value: true",
+        },
         handleOpen: { table: { disable: true } },
         handleClose: { table: { disable: true } },
         onOpen: {

--- a/lib/components/ActionSheet/mocks/example.tsx
+++ b/lib/components/ActionSheet/mocks/example.tsx
@@ -23,6 +23,8 @@ export const ActionSheetExample = ({
     shouldCloseOnPrimaryButtonClick,
     shouldCloseOnSecondaryButtonClick,
     shouldCloseOnDrag,
+    showHandlebar,
+    shouldDetectSwipingOnContainer,
     fullHeightOnOpen,
     isPrimaryButtonDisabled,
     isSecondaryButtonDisabled,
@@ -38,6 +40,10 @@ export const ActionSheetExample = ({
                 <ActionSheet.Trigger label="Click Here" />
                 <ActionSheet.Portal
                     shouldCloseOnDrag={shouldCloseOnDrag}
+                    shouldDetectSwipingOnContainer={
+                        shouldDetectSwipingOnContainer
+                    }
+                    showHandlebar={showHandlebar}
                     fullHeightOnOpen={fullHeightOnOpen}
                 >
                     <ActionSheet.Header
@@ -93,6 +99,8 @@ export const ActionSheetExampleWithIconTrigger = ({
     shouldCloseOnPrimaryButtonClick,
     shouldCloseOnSecondaryButtonClick,
     shouldCloseOnDrag,
+    shouldDetectSwipingOnContainer,
+    showHandlebar,
     fullHeightOnOpen,
     isPrimaryButtonDisabled,
     isSecondaryButtonDisabled,
@@ -107,6 +115,10 @@ export const ActionSheetExampleWithIconTrigger = ({
                 />
                 <ActionSheet.Portal
                     shouldCloseOnDrag={shouldCloseOnDrag}
+                    shouldDetectSwipingOnContainer={
+                        shouldDetectSwipingOnContainer
+                    }
+                    showHandlebar={showHandlebar}
                     fullHeightOnOpen={fullHeightOnOpen}
                 >
                     <ActionSheet.Header
@@ -212,6 +224,8 @@ export const ActionSheetExampleControlled = ({
     shouldCloseOnPrimaryButtonClick,
     shouldCloseOnSecondaryButtonClick,
     shouldCloseOnDrag,
+    shouldDetectSwipingOnContainer,
+    showHandlebar,
     fullHeightOnOpen,
     isPrimaryButtonDisabled,
     isSecondaryButtonDisabled,
@@ -222,6 +236,10 @@ export const ActionSheetExampleControlled = ({
             <ActionSheet.Root {...props}>
                 <ActionSheet.Portal
                     shouldCloseOnDrag={shouldCloseOnDrag}
+                    shouldDetectSwipingOnContainer={
+                        shouldDetectSwipingOnContainer
+                    }
+                    showHandlebar={showHandlebar}
                     fullHeightOnOpen={fullHeightOnOpen}
                 >
                     <ActionSheet.Header

--- a/lib/components/ActionSheet/portal/index.tsx
+++ b/lib/components/ActionSheet/portal/index.tsx
@@ -8,12 +8,16 @@ import clsx from "clsx";
 
 interface PortalProps extends ComponentProps<"div"> {
     shouldCloseOnDrag?: boolean;
+    shouldDetectSwipingOnContainer?: boolean;
+    showHandlebar?: boolean;
     fullHeightOnOpen?: boolean;
 }
 
 const Portal = ({
     children,
     shouldCloseOnDrag,
+    shouldDetectSwipingOnContainer = false,
+    showHandlebar = true,
     fullHeightOnOpen = false,
     ...restProps
 }: PortalProps) => {
@@ -54,11 +58,21 @@ const Portal = ({
                             )}
                             ref={containerRef}
                             style={{ height }}
-                            {...(!isScrolled && !isLg && expandable
+                            {...(shouldDetectSwipingOnContainer &&
+                            !isScrolled &&
+                            !isLg &&
+                            expandable
                                 ? bindHandle()
                                 : {})}
                         >
-                            {expandable && <HandleBar {...bindHandle()} />}
+                            {showHandlebar && (
+                                <HandleBar
+                                    {...(expandable || shouldCloseOnDrag
+                                        ? bindHandle()
+                                        : {})}
+                                />
+                            )}
+
                             {children}
                         </div>
                     </div>

--- a/lib/hooks/useSwipeBlock/index.ts
+++ b/lib/hooks/useSwipeBlock/index.ts
@@ -61,7 +61,9 @@ export const useSwipeBlock = ({
 
             const clientHeight = containerRef.current?.clientHeight || 0;
             let draggingPoint = clientHeight;
-            const isGoingDown = initial[1] < xy[1];
+            const isGoingDown =
+                initial[1] < xy[1] &&
+                Math.abs(initial[1] - xy[1]) > Math.abs(initial[0] - xy[0]);
 
             if (isGoingDown) {
                 draggingPoint = draggingPoint - distance[1];


### PR DESCRIPTION
I hope I didn't forget anything.
- Make applying swipe handlers to whole component optional (controlled via `shouldDetectSwipingOnContainer` prop). By default, swiping will be detected only by `Handlebar`.
- Now, `expandable` prop exists only for controlling expanding/collapsing (just height change on swipe).
- Visibility of `Handlebar` is not connected with `expandable` prop anymore. Now we have `showHandlebar` prop.
- Refactored calculations of the `isGoingDown` marker: now it also checks the ratio of the difference between vertical and horizontal coordinates to eliminate false positives on a horizontal swipe.
