### PR TITLE
DTRA-1478 / Kate / Action sheet component improvement

### DIFF
--- a/lib/components/ActionSheet/footer/index.tsx
+++ b/lib/components/ActionSheet/footer/index.tsx
@@ -1,11 +1,10 @@
 import { FooterProps } from "../types";
-import { useContext } from "react";
-import { ActionSheetContext } from "../root";
 import clsx from "clsx";
 import "./footer.scss";
 import { Button } from "@components/Button";
 
 const Footer = ({
+    handleClose,
     primaryAction,
     secondaryAction,
     alignment,
@@ -16,7 +15,6 @@ const Footer = ({
     isSecondaryButtonDisabled,
     ...rest
 }: FooterProps) => {
-    const { handleClose } = useContext(ActionSheetContext);
     if (!primaryAction && !secondaryAction) return null;
 
     const primaryActionHandler = () => {

--- a/lib/components/ActionSheet/handle-bar/handle-bar.scss
+++ b/lib/components/ActionSheet/handle-bar/handle-bar.scss
@@ -15,8 +15,8 @@
         height: var(--core-size-2400);
         width: 100%;
         position: absolute;
-        top: 0px;
-        left: 0px;
+        top: 0;
+        inset-inline-start: 0;
     }
 
     @include breakpoint("lg") {

--- a/lib/components/ActionSheet/handle-bar/handle-bar.scss
+++ b/lib/components/ActionSheet/handle-bar/handle-bar.scss
@@ -2,11 +2,22 @@
 
 .quill-action-sheet--handle-bar {
     position: sticky;
+    z-index: 1;
     display: flex;
     touch-action: none;
     align-items: center;
     justify-content: center;
     padding-block: var(--component-actionSheet-spacing-padding-sm);
+
+    &::before {
+        content: "";
+        display: block;
+        height: var(--core-size-2400);
+        width: 100%;
+        position: absolute;
+        top: 0px;
+        left: 0px;
+    }
 
     @include breakpoint("lg") {
         display: none;

--- a/lib/components/ActionSheet/portal/__tests__/portal.test.tsx
+++ b/lib/components/ActionSheet/portal/__tests__/portal.test.tsx
@@ -44,8 +44,7 @@ jest.mock("usehooks-ts", () => ({
     })),
 }));
 
-const mock_loadash = jest.fn((fn) => fn);
-jest.mock("lodash/debounce", () => mock_loadash);
+jest.mock("lodash.debounce", () => jest.fn((fn) => fn));
 
 describe("<ActionSheet.Portal/>", () => {
     it('should set the data-state attribute to "open" when the show is true', async () => {

--- a/lib/components/ActionSheet/portal/__tests__/portal.test.tsx
+++ b/lib/components/ActionSheet/portal/__tests__/portal.test.tsx
@@ -9,14 +9,14 @@ import userEvent from "@testing-library/user-event";
 import { RootPosition, RootProps } from "../../types";
 import ActionSheet from "@components/ActionSheet";
 
-const dialog_state = {
-    open: "open",
-    close: "close",
+const DIALOG_STATE = {
+    OPEN: "open",
+    CLOSE: "close",
 };
 
-const button_name = {
-    trigger: "Trigger",
-    close: "Close",
+const BUTTON_NAME = {
+    TRIGGER: "Trigger",
+    CLOSE: "Close",
 };
 
 const overlay = "dt-actionsheet-overlay";
@@ -47,45 +47,45 @@ describe("<ActionSheet.Portal/>", () => {
     it('should set the data-state attribute to "open" when the show is true', async () => {
         render(
             <>
-                <ActionSheet.Trigger>{button_name.trigger}</ActionSheet.Trigger>
+                <ActionSheet.Trigger>{BUTTON_NAME.TRIGGER}</ActionSheet.Trigger>
                 <ActionSheet.Portal>Portal</ActionSheet.Portal>
             </>,
         );
 
-        const trigger = screen.getByText(button_name.trigger);
+        const trigger = screen.getByText(BUTTON_NAME.TRIGGER);
         await act(async () => {
             await userEvent.click(trigger);
         });
         const state = screen.getByRole("dialog").getAttribute("data-state");
 
-        expect(state).toBe(dialog_state.open);
+        expect(state).toBe(DIALOG_STATE.OPEN);
     });
 
     it("should not render the component if show is false", async () => {
         render(
             <>
-                <ActionSheet.Trigger>{button_name.trigger}</ActionSheet.Trigger>
+                <ActionSheet.Trigger>{BUTTON_NAME.TRIGGER}</ActionSheet.Trigger>
                 <ActionSheet.Portal>
-                    <ActionSheet.Header closeIcon={button_name.close} />
+                    <ActionSheet.Header closeIcon={BUTTON_NAME.CLOSE} />
                 </ActionSheet.Portal>
             </>,
         );
 
-        const trigger = screen.getByText(button_name.trigger);
+        const trigger = screen.getByText(BUTTON_NAME.TRIGGER);
         await act(async () => {
             await userEvent.click(trigger);
         });
-        const close = screen.getByText(button_name.close);
+        const close = screen.getByText(BUTTON_NAME.CLOSE);
         await act(async () => {
             await userEvent.click(close);
         });
 
-        expect(screen.queryByText(button_name.close)).not.toBeInTheDocument();
+        expect(screen.queryByText(BUTTON_NAME.CLOSE)).not.toBeInTheDocument();
     });
     it("should render overlay when type prop is modal", async () => {
         render(
             <>
-                <ActionSheet.Trigger>{button_name.trigger}</ActionSheet.Trigger>
+                <ActionSheet.Trigger>{BUTTON_NAME.TRIGGER}</ActionSheet.Trigger>
                 <ActionSheet.Portal>Portal</ActionSheet.Portal>
             </>,
             {
@@ -95,7 +95,7 @@ describe("<ActionSheet.Portal/>", () => {
             },
         );
 
-        const trigger = screen.getByText(button_name.trigger);
+        const trigger = screen.getByText(BUTTON_NAME.TRIGGER);
         await act(async () => {
             await userEvent.click(trigger);
         });
@@ -106,7 +106,7 @@ describe("<ActionSheet.Portal/>", () => {
     it("should not render overlay when type prop is non-modal", async () => {
         render(
             <>
-                <ActionSheet.Trigger>{button_name.trigger}</ActionSheet.Trigger>
+                <ActionSheet.Trigger>{BUTTON_NAME.TRIGGER}</ActionSheet.Trigger>
                 <ActionSheet.Portal>Portal</ActionSheet.Portal>
             </>,
             {
@@ -116,7 +116,7 @@ describe("<ActionSheet.Portal/>", () => {
             },
         );
 
-        const trigger = screen.getByText(button_name.trigger);
+        const trigger = screen.getByText(BUTTON_NAME.TRIGGER);
         await act(async () => {
             await userEvent.click(trigger);
         });
@@ -127,12 +127,12 @@ describe("<ActionSheet.Portal/>", () => {
     it("should close the action sheet when user clicked on overlay", async () => {
         render(
             <>
-                <ActionSheet.Trigger>Trigger</ActionSheet.Trigger>
+                <ActionSheet.Trigger>{BUTTON_NAME.TRIGGER}</ActionSheet.Trigger>
                 <ActionSheet.Portal>Portal</ActionSheet.Portal>
             </>,
         );
 
-        const trigger = screen.getByText(button_name.trigger);
+        const trigger = screen.getByText(BUTTON_NAME.TRIGGER);
         await act(async () => {
             await userEvent.click(trigger);
         });
@@ -142,7 +142,7 @@ describe("<ActionSheet.Portal/>", () => {
         });
         const state = screen.getByRole("dialog").getAttribute("data-state");
 
-        expect(state).toBe(dialog_state.close);
+        expect(state).toBe(DIALOG_STATE.CLOSE);
     });
     it("should render handle bar when expandable prop is true", async () => {
         render(
@@ -154,7 +154,7 @@ describe("<ActionSheet.Portal/>", () => {
                 wrapperProps: { expandable: true },
             },
         );
-        const trigger = screen.getByText(button_name.trigger);
+        const trigger = screen.getByText(BUTTON_NAME.TRIGGER);
         await act(async () => {
             await userEvent.click(trigger);
         });
@@ -165,13 +165,13 @@ describe("<ActionSheet.Portal/>", () => {
     it("should not render handle bar when showHandlebar prop is false", async () => {
         render(
             <>
-                <ActionSheet.Trigger>Trigger</ActionSheet.Trigger>
+                <ActionSheet.Trigger>{BUTTON_NAME.TRIGGER}</ActionSheet.Trigger>
                 <ActionSheet.Portal showHandlebar={false}>
                     Portal
                 </ActionSheet.Portal>
             </>,
         );
-        const trigger = screen.getByText(button_name.trigger);
+        const trigger = screen.getByText(BUTTON_NAME.TRIGGER);
         await act(async () => {
             await userEvent.click(trigger);
         });

--- a/lib/components/ActionSheet/portal/__tests__/portal.test.tsx
+++ b/lib/components/ActionSheet/portal/__tests__/portal.test.tsx
@@ -9,6 +9,18 @@ import userEvent from "@testing-library/user-event";
 import { RootPosition, RootProps } from "../../types";
 import ActionSheet from "@components/ActionSheet";
 
+const dialog_state = {
+    open: "open",
+    close: "close",
+};
+
+const button_name = {
+    trigger: "Trigger",
+    close: "Close",
+};
+
+const overlay = "dt-actionsheet-overlay";
+
 const render = (
     ui: React.ReactElement,
     options?: RenderOptions & {
@@ -35,54 +47,81 @@ describe("<ActionSheet.Portal/>", () => {
     it('should set the data-state attribute to "open" when the show is true', async () => {
         render(
             <>
-                <ActionSheet.Trigger>Trigger</ActionSheet.Trigger>
+                <ActionSheet.Trigger>{button_name.trigger}</ActionSheet.Trigger>
                 <ActionSheet.Portal>Portal</ActionSheet.Portal>
             </>,
         );
-        const trigger = screen.getByText("Trigger");
+
+        const trigger = screen.getByText(button_name.trigger);
         await act(async () => {
             await userEvent.click(trigger);
         });
         const state = screen.getByRole("dialog").getAttribute("data-state");
-        expect(state).toBe("open");
+
+        expect(state).toBe(dialog_state.open);
     });
 
-    it('should set the data-state attribute to "close" when the show is false', async () => {
+    it("should not render the component if show is false", async () => {
         render(
             <>
-                <ActionSheet.Trigger>Trigger</ActionSheet.Trigger>
+                <ActionSheet.Trigger>{button_name.trigger}</ActionSheet.Trigger>
                 <ActionSheet.Portal>
-                    <ActionSheet.Header closeIcon="Close" />
+                    <ActionSheet.Header closeIcon={button_name.close} />
                 </ActionSheet.Portal>
             </>,
         );
-        const trigger = screen.getByText("Trigger");
+
+        const trigger = screen.getByText(button_name.trigger);
         await act(async () => {
             await userEvent.click(trigger);
         });
-        const close = screen.getByText("Close");
+        const close = screen.getByText(button_name.close);
         await act(async () => {
             await userEvent.click(close);
         });
-        const state = screen.getByRole("dialog").getAttribute("data-state");
-        expect(state).toBe("close");
+
+        expect(screen.queryByText(button_name.close)).not.toBeInTheDocument();
     });
-    it("should render overlay when type prop is modal", () => {
-        render(<ActionSheet.Portal>Portal</ActionSheet.Portal>, {
-            wrapperProps: {
-                type: "modal",
+    it("should render overlay when type prop is modal", async () => {
+        render(
+            <>
+                <ActionSheet.Trigger>{button_name.trigger}</ActionSheet.Trigger>
+                <ActionSheet.Portal>Portal</ActionSheet.Portal>
+            </>,
+            {
+                wrapperProps: {
+                    type: "modal",
+                },
             },
+        );
+
+        const trigger = screen.getByText(button_name.trigger);
+        await act(async () => {
+            await userEvent.click(trigger);
         });
-        const modalOverlay = screen.getByTestId("dt-actionsheet-overlay");
+        const modalOverlay = screen.getByTestId(overlay);
+
         expect(modalOverlay).toBeInTheDocument();
     });
-    it("should not render overlay when type prop is non-modal", () => {
-        render(<ActionSheet.Portal>Portal</ActionSheet.Portal>, {
-            wrapperProps: {
-                type: "non-modal",
+    it("should not render overlay when type prop is non-modal", async () => {
+        render(
+            <>
+                <ActionSheet.Trigger>{button_name.trigger}</ActionSheet.Trigger>
+                <ActionSheet.Portal>Portal</ActionSheet.Portal>
+            </>,
+            {
+                wrapperProps: {
+                    type: "non-modal",
+                },
             },
+        );
+
+        const trigger = screen.getByText(button_name.trigger);
+        await act(async () => {
+            await userEvent.click(trigger);
         });
-        const modalOverlay = screen.queryByTestId("dt-actionsheet-overlay");
+        const modalOverlay = screen.queryByTestId(overlay);
+
         expect(modalOverlay).not.toBeInTheDocument();
     });
     it("should close the action sheet when user clicked on overlay", async () => {
@@ -92,30 +131,51 @@ describe("<ActionSheet.Portal/>", () => {
                 <ActionSheet.Portal>Portal</ActionSheet.Portal>
             </>,
         );
-        const trigger = screen.getByText("Trigger");
+
+        const trigger = screen.getByText(button_name.trigger);
         await act(async () => {
             await userEvent.click(trigger);
         });
-        const modalOverlay = screen.getByTestId("dt-actionsheet-overlay");
+        const modalOverlay = screen.getByTestId(overlay);
         await act(async () => {
             await userEvent.click(modalOverlay);
         });
         const state = screen.getByRole("dialog").getAttribute("data-state");
-        expect(state).toBe("close");
+
+        expect(state).toBe(dialog_state.close);
     });
-    it("should render handle bar when expandable prop is true", () => {
-        render(<ActionSheet.Portal>Portal</ActionSheet.Portal>, {
-            wrapperProps: { expandable: true },
+    it("should render handle bar when expandable prop is true", async () => {
+        render(
+            <>
+                <ActionSheet.Trigger>Trigger</ActionSheet.Trigger>
+                <ActionSheet.Portal>Portal</ActionSheet.Portal>
+            </>,
+            {
+                wrapperProps: { expandable: true },
+            },
+        );
+        const trigger = screen.getByText(button_name.trigger);
+        await act(async () => {
+            await userEvent.click(trigger);
         });
         const handleBar = screen.getByTestId("dt-actionsheet-handle-bar");
+
         expect(handleBar).toBeInTheDocument();
     });
-    it("should not render handle bar when showHandlebar prop is false", () => {
+    it("should not render handle bar when showHandlebar prop is false", async () => {
         render(
-            <ActionSheet.Portal showHandlebar={false}>
-                Portal
-            </ActionSheet.Portal>,
+            <>
+                <ActionSheet.Trigger>Trigger</ActionSheet.Trigger>
+                <ActionSheet.Portal showHandlebar={false}>
+                    Portal
+                </ActionSheet.Portal>
+            </>,
         );
+        const trigger = screen.getByText(button_name.trigger);
+        await act(async () => {
+            await userEvent.click(trigger);
+        });
+
         const handleBar = screen.queryByTestId("dt-actionsheet-handle-bar");
         expect(handleBar).not.toBeInTheDocument();
     });
@@ -124,9 +184,11 @@ describe("<ActionSheet.Portal/>", () => {
     positions.forEach((position) => {
         it(`should render correctly with position ${position}`, () => {
             render(
-                <ActionSheet.Portal>
-                    <p>{position} portal</p>
-                </ActionSheet.Portal>,
+                <ActionSheet.Root isOpen>
+                    <ActionSheet.Portal>
+                        <p>{position} portal</p>
+                    </ActionSheet.Portal>
+                </ActionSheet.Root>,
                 {
                     wrapperProps: {
                         position,

--- a/lib/components/ActionSheet/portal/__tests__/portal.test.tsx
+++ b/lib/components/ActionSheet/portal/__tests__/portal.test.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import {
     screen,
     render as rtlRender,
@@ -42,6 +43,9 @@ jest.mock("usehooks-ts", () => ({
         isServer: false,
     })),
 }));
+
+const mock_loadash = jest.fn((fn) => fn);
+jest.mock("lodash/debounce", () => mock_loadash);
 
 describe("<ActionSheet.Portal/>", () => {
     it('should set the data-state attribute to "open" when the show is true', async () => {
@@ -124,7 +128,13 @@ describe("<ActionSheet.Portal/>", () => {
 
         expect(modalOverlay).not.toBeInTheDocument();
     });
-    it("should close the action sheet when user clicked on overlay", async () => {
+    it("should set state to false when user clicked on overlay", async () => {
+        const mockSetChangedOptions = jest.fn();
+        jest.spyOn(React, "useState").mockImplementationOnce(() => [
+            true,
+            mockSetChangedOptions,
+        ]);
+
         render(
             <>
                 <ActionSheet.Trigger>{BUTTON_NAME.TRIGGER}</ActionSheet.Trigger>
@@ -132,17 +142,12 @@ describe("<ActionSheet.Portal/>", () => {
             </>,
         );
 
-        const trigger = screen.getByText(BUTTON_NAME.TRIGGER);
-        await act(async () => {
-            await userEvent.click(trigger);
-        });
         const modalOverlay = screen.getByTestId(overlay);
         await act(async () => {
             await userEvent.click(modalOverlay);
         });
-        const state = screen.getByRole("dialog").getAttribute("data-state");
 
-        expect(state).toBe(DIALOG_STATE.CLOSE);
+        expect(mockSetChangedOptions).toHaveBeenCalledWith(false);
     });
     it("should render handle bar when expandable prop is true", async () => {
         render(

--- a/lib/components/ActionSheet/portal/index.tsx
+++ b/lib/components/ActionSheet/portal/index.tsx
@@ -50,10 +50,10 @@ const Portal = forwardRef<HTMLDivElement, PortalProps>(
             animationTimerRef.current = setTimeout(() => handleClose?.(), 300);
         };
 
-        useEffect(() => setIsVisible(show), [show]);
         useEffect(() => {
+            setIsVisible(show);
             return () => clearTimeout(animationTimerRef.current);
-        }, []);
+        }, [show]);
 
         if (!show) return null;
 

--- a/lib/components/ActionSheet/portal/index.tsx
+++ b/lib/components/ActionSheet/portal/index.tsx
@@ -22,12 +22,11 @@ interface PortalProps extends ComponentProps<"div"> {
     fullHeightOnOpen?: boolean;
 }
 
-type TCustomConstructor = React.JSXElementConstructor<{
-    handleClose: () => void;
-}>;
-type TChild = React.ReactElement<
-    { handleClose: () => void },
-    TCustomConstructor
+type TFooterChildProps = { handleClose: () => void };
+type TFooterJSXConstructor = React.JSXElementConstructor<TFooterChildProps>;
+type TFooterChild = React.ReactElement<
+    TFooterChildProps,
+    TFooterJSXConstructor
 >;
 
 const Portal = forwardRef<HTMLDivElement, PortalProps>(
@@ -56,9 +55,9 @@ const Portal = forwardRef<HTMLDivElement, PortalProps>(
         const childrenWithProps = React.Children.map(children, (child) => {
             if (
                 React.isValidElement(child) &&
-                (child?.type as TCustomConstructor)?.name === "Footer"
+                (child?.type as TFooterJSXConstructor)?.name === "Footer"
             ) {
-                return React.cloneElement(child as TChild, {
+                return React.cloneElement(child as TFooterChild, {
                     handleClose: toggleHandler,
                 });
             }

--- a/lib/components/ActionSheet/portal/index.tsx
+++ b/lib/components/ActionSheet/portal/index.tsx
@@ -1,4 +1,11 @@
-import { ComponentProps, forwardRef, useContext } from "react";
+import {
+    ComponentProps,
+    forwardRef,
+    useContext,
+    useState,
+    useEffect,
+    useRef,
+} from "react";
 import { createPortal } from "react-dom";
 import HandleBar from "../handle-bar";
 import "./portal.scss";
@@ -35,6 +42,21 @@ const Portal = forwardRef<HTMLDivElement, PortalProps>(
                 fullHeightOnOpen,
             });
 
+        const [isVisible, setIsVisible] = useState(show);
+        const animationTimerRef = useRef<ReturnType<typeof setTimeout>>();
+
+        const toggleHandler = () => {
+            setIsVisible(!isVisible);
+            animationTimerRef.current = setTimeout(() => handleClose?.(), 300);
+        };
+
+        useEffect(() => setIsVisible(show), [show]);
+        useEffect(() => {
+            return () => clearTimeout(animationTimerRef.current);
+        }, []);
+
+        if (!show) return null;
+
         return (
             <>
                 {createPortal(
@@ -42,23 +64,23 @@ const Portal = forwardRef<HTMLDivElement, PortalProps>(
                         <div
                             className="quill-action-sheet--portal quill-action-sheet--portal--wrapper"
                             role="dialog"
-                            data-state={show ? "open" : "close"}
+                            data-state={isVisible ? "open" : "close"}
                             ref={ref}
                             {...restProps}
                         >
                             {type === "modal" && (
                                 <div
                                     data-testid="dt-actionsheet-overlay"
-                                    onClick={handleClose}
+                                    onClick={toggleHandler}
                                     className="quill-action-sheet--portal quill-action-sheet--portal__variant--modal"
                                 />
                             )}
                             <div
                                 className={clsx(
                                     "quill-action-sheet--root",
-                                    `quill-action-sheet--root__show--${show}`,
+                                    `quill-action-sheet--root__show--${isVisible}`,
                                     `quill-action-sheet--root__position--${position}`,
-                                    `quill-action-sheet--root__position--${position}__show--${show}`,
+                                    `quill-action-sheet--root__position--${position}__show--${isVisible}`,
                                     className,
                                 )}
                                 ref={containerRef}

--- a/lib/components/ActionSheet/types.ts
+++ b/lib/components/ActionSheet/types.ts
@@ -34,6 +34,7 @@ interface ActionType {
 export interface FooterProps
     extends ComponentPropsWithoutRef<"div">,
         actionSheetFooterCVA {
+    handleClose?: () => void;
     primaryAction?: ActionType;
     secondaryAction?: ActionType;
     shouldCloseOnPrimaryButtonClick?: boolean;

--- a/lib/hooks/useSwipeBlock/index.ts
+++ b/lib/hooks/useSwipeBlock/index.ts
@@ -3,6 +3,7 @@ import { useDrag } from "@use-gesture/react";
 import { useMediaQuery } from "usehooks-ts";
 
 interface SwipeBlockType {
+    expandable?: boolean;
     show?: boolean;
     onClose?: () => void;
     shouldCloseOnDrag?: boolean;
@@ -10,6 +11,7 @@ interface SwipeBlockType {
 }
 
 export const useSwipeBlock = ({
+    expandable,
     show,
     onClose,
     shouldCloseOnDrag,
@@ -77,7 +79,7 @@ export const useSwipeBlock = ({
                     return;
                 }
                 setHeight(`${draggingPoint}px`);
-            } else {
+            } else if (expandable) {
                 if (distance[1] === 0) return;
                 if (!isGoingDown) {
                     if (

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
                 "@testing-library/react": "^14.2.1",
                 "@testing-library/user-event": "^14.5.2",
                 "@types/jest": "^29.5.12",
+                "@types/lodash.debounce": "^4.0.7",
                 "@types/node": "^20.10.7",
                 "@types/react": "18.2.43",
                 "@types/react-dom": "18.2.17",
@@ -8493,6 +8494,15 @@
             "version": "4.17.5",
             "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.5.tgz",
             "integrity": "sha512-MBIOHVZqVqgfro1euRDWX7OO0fBVUUMrN6Pwm8LQsz8cWhEpihlvR70ENj3f40j58TNxZaWv2ndSkInykNBBJw=="
+        },
+        "node_modules/@types/lodash.debounce": {
+            "version": "4.0.9",
+            "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.9.tgz",
+            "integrity": "sha512-Ma5JcgTREwpLRwMM+XwBR7DaWe96nC38uCBDFKZWbNKD+osjVzdpnUSwBcqCptrp16sSOLBAUb50Car5I0TCsQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/lodash": "*"
+            }
         },
         "node_modules/@types/mdx": {
             "version": "2.0.13",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
         "@types/node": "^20.10.7",
         "@types/react": "18.2.43",
         "@types/react-dom": "18.2.17",
+        "@types/lodash.debounce": "^4.0.7",
         "@typescript-eslint/eslint-plugin": "^6.14.0",
         "@typescript-eslint/parser": "^6.14.0",
         "@use-gesture/react": "^10.3.1",


### PR DESCRIPTION
Refactored `ActionSheet` component from Quill UI:
1) Unmount `ActionSheet` component (not just hide with css) when props `is_open` is falsy. In DTrader for such purpose we are using `CSSTransition`, but as it required new npm package installation I decided to do it with `setTimeout`.
2) Increase draggable area of handle bar in order to improve UX (by adding pseudo-element with height 48px for handle bar). Swipable area is marked with red color on the screenshot).
3) Add npm package `@types/lodash.debounce`
4) In _lib/components/ActionSheet/portal/index.tsx_ added props passing (`toggleHandler`) from parent component to Children (only for Footer). I was forced to do it, because Footer buttons are among children.

![Screenshot 2024-07-16 at 5 10 00 PM](https://github.com/user-attachments/assets/a821efe1-1a04-46bd-b9a7-4b445387c63c)


https://github.com/user-attachments/assets/d9bead97-863b-41af-a295-6f5cc7354b0d

<img width="1005" alt="Screenshot 2024-07-16 at 5 52 05 PM" src="https://github.com/user-attachments/assets/98ea5237-56c5-4dde-b540-21f97f63f9aa">

