### PR TITLE
Ahmad/Tags/Allowing non text label without warning

### DIFF
--- a/lib/components/Tag/index.tsx
+++ b/lib/components/Tag/index.tsx
@@ -48,19 +48,24 @@ export const Tag = forwardRef<HTMLDivElement, BaseTagProps>(
                         size={size}
                     />
                 )}
-
-                {size === "sm" || size === "xs" ? (
-                    <CaptionText bold={isBold} color={tagColor}>
-                        {label}
-                    </CaptionText>
+                {typeof label !== "string" ? (
+                    label
                 ) : (
-                    <Text
-                        size={size === "md" ? "sm" : "md"}
-                        bold={isBold}
-                        color={tagColor}
-                    >
-                        {label}
-                    </Text>
+                    <>
+                        {size === "sm" || size === "xs" ? (
+                            <CaptionText bold={isBold} color={tagColor}>
+                                {label}
+                            </CaptionText>
+                        ) : (
+                            <Text
+                                size={size === "md" ? "sm" : "md"}
+                                bold={isBold}
+                                color={tagColor}
+                            >
+                                {label}
+                            </Text>
+                        )}
+                    </>
                 )}
             </div>
         );


### PR DESCRIPTION
This update modifies the Tags component to support non-text labels, such as JSX or other React elements, without generating console warnings I was getting a console warning when I was using the Tags with a JSX as label 
![Screenshot 2024-07-17 at 2 16 34 PM](https://github.com/user-attachments/assets/b0870643-67ab-4e47-a800-0e995e471b71)
