### PR TITLE
DTRA-1469 / Kate / Refactor: ToggleSwitch and ActionSheet

### DIFF
--- a/lib/components/ActionSheet/button-trigger.stories.tsx
+++ b/lib/components/ActionSheet/button-trigger.stories.tsx
@@ -109,6 +109,12 @@ const meta: Meta = {
             mapping: icons,
             control: "radio",
         },
+        iconPosition: {
+            control: "radio",
+            options: ["left", "right"],
+            description:
+                "This prop controls icon position in `ActionSheet.Header`. Default value - 'right'",
+        },
         primaryAction: {
             control: false,
             description:

--- a/lib/components/ActionSheet/controlled.stories.tsx
+++ b/lib/components/ActionSheet/controlled.stories.tsx
@@ -111,6 +111,12 @@ const meta: Meta = {
                 type: "radio",
             },
         },
+        iconPosition: {
+            control: "radio",
+            options: ["left", "right"],
+            description:
+                "This prop controls icon position in `ActionSheet.Header`. Default value - 'right'",
+        },
         primaryAction: {
             control: {
                 type: "object",

--- a/lib/components/ActionSheet/footer/index.tsx
+++ b/lib/components/ActionSheet/footer/index.tsx
@@ -1,10 +1,11 @@
 import { FooterProps } from "../types";
+import { useContext } from "react";
+import { ActionSheetContext } from "../root";
 import clsx from "clsx";
 import "./footer.scss";
 import { Button } from "@components/Button";
 
 const Footer = ({
-    handleClose,
     primaryAction,
     secondaryAction,
     alignment,
@@ -15,6 +16,7 @@ const Footer = ({
     isSecondaryButtonDisabled,
     ...rest
 }: FooterProps) => {
+    const { handleClose } = useContext(ActionSheetContext);
     if (!primaryAction && !secondaryAction) return null;
 
     const primaryActionHandler = () => {

--- a/lib/components/ActionSheet/header/header.scss
+++ b/lib/components/ActionSheet/header/header.scss
@@ -42,7 +42,14 @@
             fill: var(--component-textIcon-normal-prominent);
             position: absolute;
             top: 0;
-            right: 0;
+
+            &--right {
+                right: 0;
+            }
+
+            &--left {
+                left: 0;
+            }
 
             @include breakpoint("lg") {
                 left: 0;

--- a/lib/components/ActionSheet/header/header.scss
+++ b/lib/components/ActionSheet/header/header.scss
@@ -44,15 +44,15 @@
             top: 0;
 
             &--right {
-                right: 0;
+                inset-inline-end: 0;
             }
 
             &--left {
-                left: 0;
+                inset-inline-start: 0;
             }
 
             @include breakpoint("lg") {
-                left: 0;
+                inset-inline-start: 0;
             }
 
             &--close {

--- a/lib/components/ActionSheet/header/index.tsx
+++ b/lib/components/ActionSheet/header/index.tsx
@@ -9,6 +9,7 @@ interface HeaderProps extends Omit<ComponentPropsWithoutRef<"div">, "title"> {
     title?: ReactNode;
     description?: ReactNode;
     icon?: ReactNode;
+    iconPosition?: "right" | "left";
     closeIcon?: ReactNode;
 }
 
@@ -17,6 +18,7 @@ const Header = ({
     title,
     description,
     icon: Icon,
+    iconPosition = "right",
     closeIcon: CloseIcon,
     ...rest
 }: HeaderProps) => {
@@ -35,7 +37,12 @@ const Header = ({
         >
             <div className="quill-action-sheet--title">
                 {Icon && (
-                    <div className="quill-action-sheet--title--icon">
+                    <div
+                        className={clsx(
+                            "quill-action-sheet--title--icon",
+                            `quill-action-sheet--title--icon--${iconPosition}`,
+                        )}
+                    >
                         {Icon}
                     </div>
                 )}

--- a/lib/components/ActionSheet/icon-trigger.stories.tsx
+++ b/lib/components/ActionSheet/icon-trigger.stories.tsx
@@ -133,6 +133,12 @@ const meta: Meta = {
                 type: "radio",
             },
         },
+        iconPosition: {
+            control: "radio",
+            options: ["left", "right"],
+            description:
+                "This prop controls icon position in `ActionSheet.Header`. Default value - 'right'",
+        },
         alignment: {
             control: {
                 type: "radio",

--- a/lib/components/ActionSheet/mocks/example.tsx
+++ b/lib/components/ActionSheet/mocks/example.tsx
@@ -20,6 +20,7 @@ export const ActionSheetExample = ({
     title,
     closeIcon,
     icon,
+    iconPosition,
     shouldCloseOnPrimaryButtonClick,
     shouldCloseOnSecondaryButtonClick,
     shouldCloseOnDrag,
@@ -51,6 +52,7 @@ export const ActionSheetExample = ({
                         description={description}
                         closeIcon={closeIcon}
                         icon={icon}
+                        iconPosition={iconPosition}
                     />
                     <ActionSheet.Content className="mock-action-sheet--content">
                         <Text size="sm">
@@ -96,6 +98,7 @@ export const ActionSheetExampleWithIconTrigger = ({
     title,
     closeIcon,
     icon,
+    iconPosition,
     shouldCloseOnPrimaryButtonClick,
     shouldCloseOnSecondaryButtonClick,
     shouldCloseOnDrag,
@@ -126,6 +129,7 @@ export const ActionSheetExampleWithIconTrigger = ({
                         description={description}
                         closeIcon={closeIcon}
                         icon={icon}
+                        iconPosition={iconPosition}
                     />
                     <ActionSheet.Content className="mock-action-sheet--content">
                         <Text size="sm">
@@ -221,6 +225,7 @@ export const ActionSheetExampleControlled = ({
     title,
     closeIcon,
     icon,
+    iconPosition,
     shouldCloseOnPrimaryButtonClick,
     shouldCloseOnSecondaryButtonClick,
     shouldCloseOnDrag,
@@ -247,6 +252,7 @@ export const ActionSheetExampleControlled = ({
                         description={description}
                         closeIcon={closeIcon}
                         icon={icon}
+                        iconPosition={iconPosition}
                     />
                     <ActionSheet.Content className="mock-action-sheet--content">
                         <Text size="sm">

--- a/lib/components/ActionSheet/portal/__tests__/portal.test.tsx
+++ b/lib/components/ActionSheet/portal/__tests__/portal.test.tsx
@@ -44,7 +44,12 @@ jest.mock("usehooks-ts", () => ({
     })),
 }));
 
-jest.mock("lodash.debounce", () => jest.fn((fn) => fn));
+jest.mock("react-transition-group", () => ({
+    ...jest.requireActual("react-transition-group"),
+    CSSTransition: jest.fn(({ children, ...props }) => {
+        return <div>{props.in ? children : null}</div>;
+    }),
+}));
 
 describe("<ActionSheet.Portal/>", () => {
     it('should set the data-state attribute to "open" when the show is true', async () => {

--- a/lib/components/ActionSheet/portal/portal.scss
+++ b/lib/components/ActionSheet/portal/portal.scss
@@ -15,16 +15,13 @@
             align-items: flex-end;
             justify-content: center;
             overflow-x: hidden;
-
-            &[data-state="close"] {
-                visibility: hidden;
-            }
         }
 
         &__variant--modal {
+            position: fixed;
+            inset: var(--semantic-spacing-general-none);
             background-color: var(--core-color-opacity-black-500);
             pointer-events: auto;
-            z-index: -10;
         }
     }
 
@@ -45,9 +42,8 @@
         border-top-left-radius: var(--semantic-borderRadius-lg);
         border-top-right-radius: var(--semantic-borderRadius-lg);
         background-color: var(--component-actionSheet-bg);
-        transition-property: all;
-        transition-timing-function: var(--motion-easing-inandout);
-        transition-duration: var(--core-motion-duration-200);
+        transition: all var(--motion-easing-inandout)
+            var(--core-motion-duration-200);
 
         @include breakpoint("lg") {
             max-width: 360px;
@@ -55,31 +51,33 @@
             max-height: 100vh;
         }
 
+        &--enter,
+        &--exit {
+            transform: translateY(100%);
+            &:is(.position--right) {
+                @include breakpoint("lg") {
+                    transform: translateX(100%);
+                }
+            }
+            &:is(.position--left) {
+                @include breakpoint("lg") {
+                    transform: translateX(-100%);
+                }
+            }
+        }
+        &--enter-done {
+            transform: translate(0, 0);
+            transition: all var(--motion-easing-inandout)
+                var(--core-motion-duration-200);
+        }
+
         &__position {
             &--left {
-                &__show--false {
-                    visibility: hidden;
-                    transform: translateY(100%);
-
-                    @include breakpoint("lg") {
-                        transform: translateX(-100%);
-                    }
-                }
-
                 @include breakpoint("lg") {
                     margin-left: var(--semantic-spacing-general-none);
                 }
             }
             &--right {
-                &__show--false {
-                    visibility: hidden;
-                    transform: translateY(100%);
-
-                    @include breakpoint("lg") {
-                        transform: translateX(100%);
-                    }
-                }
-
                 @include breakpoint("lg") {
                     margin-right: var(--semantic-spacing-general-none);
                 }

--- a/lib/components/ActionSheet/types.ts
+++ b/lib/components/ActionSheet/types.ts
@@ -34,7 +34,6 @@ interface ActionType {
 export interface FooterProps
     extends ComponentPropsWithoutRef<"div">,
         actionSheetFooterCVA {
-    handleClose?: () => void;
     primaryAction?: ActionType;
     secondaryAction?: ActionType;
     shouldCloseOnPrimaryButtonClick?: boolean;

--- a/lib/components/SelectionControl/toggle-switch/toggle-switch.scss
+++ b/lib/components/SelectionControl/toggle-switch/toggle-switch.scss
@@ -27,7 +27,7 @@ html.dark {
     height: var(--core-size-1400);
     border-width: var(--core-borderRadius-100);
 
-    &:focus {
+    &:focus-visible {
         outline: var(--core-borderRadius-100) solid
             var(--core-color-solid-blue-700);
         border-radius: var(--semantic-borderRadius-lg);

--- a/lib/hooks/useSwipeBlock/index.ts
+++ b/lib/hooks/useSwipeBlock/index.ts
@@ -3,7 +3,6 @@ import { useDrag } from "@use-gesture/react";
 import { useMediaQuery } from "usehooks-ts";
 
 interface SwipeBlockType {
-    expandable?: boolean;
     show?: boolean;
     onClose?: () => void;
     shouldCloseOnDrag?: boolean;
@@ -11,7 +10,6 @@ interface SwipeBlockType {
 }
 
 export const useSwipeBlock = ({
-    expandable,
     show,
     onClose,
     shouldCloseOnDrag,
@@ -79,7 +77,7 @@ export const useSwipeBlock = ({
                     return;
                 }
                 setHeight(`${draggingPoint}px`);
-            } else if (expandable) {
+            } else {
                 if (distance[1] === 0) return;
                 if (!isGoingDown) {
                     if (

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
                 "react-number-format": "^5.4.0",
                 "react-swipeable": "^6.2.1",
                 "react-tiny-popover": "^8.0.4",
+                "react-transition-group": "4.4.2",
                 "usehooks-ts": "^3.0.2",
                 "uuid": "^9.0.1"
             },
@@ -47,6 +48,7 @@
                 "@types/node": "^20.10.7",
                 "@types/react": "18.2.43",
                 "@types/react-dom": "18.2.17",
+                "@types/react-transition-group": "^4.4.4",
                 "@typescript-eslint/eslint-plugin": "^6.14.0",
                 "@typescript-eslint/parser": "^6.14.0",
                 "@use-gesture/react": "^10.3.1",
@@ -2272,7 +2274,6 @@
             "version": "7.24.7",
             "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.7.tgz",
             "integrity": "sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==",
-            "dev": true,
             "dependencies": {
                 "regenerator-runtime": "^0.14.0"
             },
@@ -8580,6 +8581,15 @@
                 "@types/react": "*"
             }
         },
+        "node_modules/@types/react-transition-group": {
+            "version": "4.4.10",
+            "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.10.tgz",
+            "integrity": "sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==",
+            "dev": true,
+            "dependencies": {
+                "@types/react": "*"
+            }
+        },
         "node_modules/@types/resolve": {
             "version": "1.20.6",
             "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.6.tgz",
@@ -11457,8 +11467,7 @@
         "node_modules/csstype": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-            "devOptional": true
+            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
         },
         "node_modules/dargs": {
             "version": "8.1.0",
@@ -11972,6 +11981,15 @@
             "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
             "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
             "dev": true
+        },
+        "node_modules/dom-helpers": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+            "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+            "dependencies": {
+                "@babel/runtime": "^7.8.7",
+                "csstype": "^3.0.2"
+            }
         },
         "node_modules/domexception": {
             "version": "4.0.0",
@@ -22680,6 +22698,21 @@
                 "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
             }
         },
+        "node_modules/react-transition-group": {
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.2.tgz",
+            "integrity": "sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==",
+            "dependencies": {
+                "@babel/runtime": "^7.5.5",
+                "dom-helpers": "^5.0.1",
+                "loose-envify": "^1.4.0",
+                "prop-types": "^15.6.2"
+            },
+            "peerDependencies": {
+                "react": ">=16.6.0",
+                "react-dom": ">=16.6.0"
+            }
+        },
         "node_modules/read-package-up": {
             "version": "11.0.0",
             "resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-11.0.0.tgz",
@@ -22879,8 +22912,7 @@
         "node_modules/regenerator-runtime": {
             "version": "0.14.1",
             "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-            "dev": true
+            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
         },
         "node_modules/regenerator-transform": {
             "version": "0.15.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,6 @@
                 "@testing-library/react": "^14.2.1",
                 "@testing-library/user-event": "^14.5.2",
                 "@types/jest": "^29.5.12",
-                "@types/lodash.debounce": "^4.0.7",
                 "@types/node": "^20.10.7",
                 "@types/react": "18.2.43",
                 "@types/react-dom": "18.2.17",
@@ -8495,15 +8494,6 @@
             "version": "4.17.5",
             "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.5.tgz",
             "integrity": "sha512-MBIOHVZqVqgfro1euRDWX7OO0fBVUUMrN6Pwm8LQsz8cWhEpihlvR70ENj3f40j58TNxZaWv2ndSkInykNBBJw=="
-        },
-        "node_modules/@types/lodash.debounce": {
-            "version": "4.0.9",
-            "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.9.tgz",
-            "integrity": "sha512-Ma5JcgTREwpLRwMM+XwBR7DaWe96nC38uCBDFKZWbNKD+osjVzdpnUSwBcqCptrp16sSOLBAUb50Car5I0TCsQ==",
-            "dev": true,
-            "dependencies": {
-                "@types/lodash": "*"
-            }
         },
         "node_modules/@types/mdx": {
             "version": "2.0.13",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
         "@types/lodash.debounce": "^4.0.7",
         "@typescript-eslint/eslint-plugin": "^6.14.0",
         "@typescript-eslint/parser": "^6.14.0",
+        "@types/react-transition-group": "^4.4.4",
         "@use-gesture/react": "^10.3.1",
         "@vitejs/plugin-react": "^4.2.1",
         "@zxcvbn-ts/core": "^3.0.4",
@@ -152,6 +153,7 @@
         "react-calendar": "^5.0.0",
         "react-number-format": "^5.4.0",
         "react-swipeable": "^6.2.1",
+        "react-transition-group": "4.4.2",
         "react-tiny-popover": "^8.0.4",
         "usehooks-ts": "^3.0.2",
         "uuid": "^9.0.1"

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
         "@types/node": "^20.10.7",
         "@types/react": "18.2.43",
         "@types/react-dom": "18.2.17",
-        "@types/lodash.debounce": "^4.0.7",
         "@typescript-eslint/eslint-plugin": "^6.14.0",
         "@typescript-eslint/parser": "^6.14.0",
         "@types/react-transition-group": "^4.4.4",


### PR DESCRIPTION
1) Added prop `iconPosition` for specifying icon position(`left` or `right`) in the header title.
2) Fix behaviour `onFocus` for `ToggleSwitcher`: previously element always stayed focused after click/tap. By replacing `:focus `---> `:focus-visible` element stayed focused onKeyDown focusing.
3) Changed approach for ActionSheet transition: instead of timer-based animation added CSSTransition package. For that I reverted all ActionSheet changes from this [PR](https://github.com/deriv-com/quill-ui/pull/303) and added react-transition-group package.
4) Updated tests and stories.