### PR TITLE
DTRA / Kate / DTRA-1354 / Fix: z-index overlapping issue

### DIFF
--- a/lib/components/ActionSheet/portal/portal.scss
+++ b/lib/components/ActionSheet/portal/portal.scss
@@ -19,6 +19,7 @@
 
         &__variant--modal {
             position: fixed;
+            z-index: 150;
             inset: var(--semantic-spacing-general-none);
             background-color: var(--core-color-opacity-black-500);
             pointer-events: auto;


### PR DESCRIPTION
Add same z-index value for overlay as for modal content in order to solve overlapping issue with multiple modals
![Screenshot 2024-07-22 at 10 10 52 AM](https://github.com/user-attachments/assets/040756c8-0590-48d2-8dbb-9469a1a6a076)
