### PR TITLE
DTRA / Kate / Refactor: introduce dvh

### DIFF
--- a/lib/components/ActionSheet/portal/portal.scss
+++ b/lib/components/ActionSheet/portal/portal.scss
@@ -35,7 +35,7 @@
         margin-left: auto;
         margin-right: auto;
         display: flex;
-        max-height: 90vh;
+        max-height: 90dvh;
         width: 100%;
         max-width: 800px;
         flex-direction: column;

--- a/lib/hooks/useSwipeBlock/index.ts
+++ b/lib/hooks/useSwipeBlock/index.ts
@@ -27,7 +27,7 @@ export const useSwipeBlock = ({
             setHeight("100%");
         }
         if (!isLg && show) {
-            fullHeightOnOpen ? setHeight("90vh") : setHeight("auto");
+            fullHeightOnOpen ? setHeight("90dvh") : setHeight("auto");
         }
     }, [show, isLg]);
 
@@ -84,23 +84,23 @@ export const useSwipeBlock = ({
                         draggingPoint >= 0 &&
                         draggingPoint <= windowHeight * 0.3
                     ) {
-                        setHeight("30vh");
+                        setHeight("30dvh");
                     } else if (
                         draggingPoint >= windowHeight * 0.3 &&
                         draggingPoint <= windowHeight * 0.5
                     ) {
-                        setHeight("50vh");
+                        setHeight("50dvh");
                     } else {
-                        setHeight("90vh");
+                        setHeight("90dvh");
                     }
                 } else {
                     if (draggingPoint <= windowHeight * 0.3) {
                         setHeight("0px");
                         onClose?.();
                     } else if (draggingPoint <= windowHeight * 0.5) {
-                        setHeight("30vh");
+                        setHeight("30dvh");
                     } else {
-                        setHeight("50vh");
+                        setHeight("50dvh");
                     }
                 }
             }


### PR DESCRIPTION
Max height for `ActionSheet` was `90vh`, but on Real device the space for URL was not counted. Hence, trying to solve this issue by replacing `vh` with `dvh`.

Screenshot of the problem
![image](https://github.com/user-attachments/assets/7c01db21-0e1e-4797-a2d1-4bd5369d8195)
