### PR TITLE
[DTRA] Maryia/feat: add isOpaque prop to Button component

### DIFF
--- a/lib/components/Atom/Calendar/__tests__/__snapshots__/date-picker.test.tsx.snap
+++ b/lib/components/Atom/Calendar/__tests__/__snapshots__/date-picker.test.tsx.snap
@@ -409,7 +409,7 @@ exports[`DatePicker should render calendar with double navigation if next2Label 
                   </abbr>
                 </button>
                 <button
-                  class="react-calendar__tile react-calendar__tile--now react-calendar__month-view__days__day"
+                  class="react-calendar__tile react-calendar__month-view__days__day"
                   style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
                   type="button"
                 >
@@ -486,7 +486,7 @@ exports[`DatePicker should render calendar with double navigation if next2Label 
                   </abbr>
                 </button>
                 <button
-                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  class="react-calendar__tile react-calendar__tile--now react-calendar__month-view__days__day"
                   style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
                   type="button"
                 >
@@ -978,7 +978,7 @@ exports[`DatePicker should render calendar with neighboring month if showNeighbo
                   </abbr>
                 </button>
                 <button
-                  class="react-calendar__tile react-calendar__tile--now react-calendar__month-view__days__day"
+                  class="react-calendar__tile react-calendar__month-view__days__day"
                   style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
                   type="button"
                 >
@@ -1055,7 +1055,7 @@ exports[`DatePicker should render calendar with neighboring month if showNeighbo
                   </abbr>
                 </button>
                 <button
-                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  class="react-calendar__tile react-calendar__tile--now react-calendar__month-view__days__day"
                   style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
                   type="button"
                 >
@@ -1525,7 +1525,7 @@ exports[`DatePicker should render calendar with range selection 1`] = `
                   </abbr>
                 </button>
                 <button
-                  class="react-calendar__tile react-calendar__tile--now react-calendar__month-view__days__day"
+                  class="react-calendar__tile react-calendar__month-view__days__day"
                   style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
                   type="button"
                 >
@@ -1602,7 +1602,7 @@ exports[`DatePicker should render calendar with range selection 1`] = `
                   </abbr>
                 </button>
                 <button
-                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  class="react-calendar__tile react-calendar__tile--now react-calendar__month-view__days__day"
                   style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
                   type="button"
                 >
@@ -2061,7 +2061,7 @@ exports[`DatePicker should render calendar with selected value and call onFormat
                   </abbr>
                 </button>
                 <button
-                  class="react-calendar__tile react-calendar__tile--now react-calendar__tile--active react-calendar__tile--range react-calendar__tile--rangeStart react-calendar__tile--rangeEnd react-calendar__tile--rangeBothEnds react-calendar__month-view__days__day"
+                  class="react-calendar__tile react-calendar__month-view__days__day"
                   style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
                   type="button"
                 >
@@ -2138,7 +2138,7 @@ exports[`DatePicker should render calendar with selected value and call onFormat
                   </abbr>
                 </button>
                 <button
-                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  class="react-calendar__tile react-calendar__tile--now react-calendar__tile--active react-calendar__tile--range react-calendar__tile--rangeStart react-calendar__tile--rangeEnd react-calendar__tile--rangeBothEnds react-calendar__month-view__days__day"
                   style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
                   type="button"
                 >
@@ -2519,7 +2519,7 @@ exports[`DatePicker should render calendar without navigation if showNavigation 
                   </abbr>
                 </button>
                 <button
-                  class="react-calendar__tile react-calendar__tile--now react-calendar__month-view__days__day"
+                  class="react-calendar__tile react-calendar__month-view__days__day"
                   style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
                   type="button"
                 >
@@ -2596,7 +2596,7 @@ exports[`DatePicker should render calendar without navigation if showNavigation 
                   </abbr>
                 </button>
                 <button
-                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  class="react-calendar__tile react-calendar__tile--now react-calendar__month-view__days__day"
                   style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
                   type="button"
                 >
@@ -3055,7 +3055,7 @@ exports[`DatePicker should render with default values if optional ones were not 
                   </abbr>
                 </button>
                 <button
-                  class="react-calendar__tile react-calendar__tile--now react-calendar__month-view__days__day"
+                  class="react-calendar__tile react-calendar__month-view__days__day"
                   style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
                   type="button"
                 >
@@ -3132,7 +3132,7 @@ exports[`DatePicker should render with default values if optional ones were not 
                   </abbr>
                 </button>
                 <button
-                  class="react-calendar__tile react-calendar__month-view__days__day"
+                  class="react-calendar__tile react-calendar__tile--now react-calendar__month-view__days__day"
                   style="flex-basis: 14.285714285714286%; flex-shrink: 0; flex-grow: 0; overflow: hidden; margin-inline-end: 0;"
                   type="button"
                 >

--- a/lib/components/Button/base/button.stories.tsx
+++ b/lib/components/Button/base/button.stories.tsx
@@ -25,6 +25,7 @@ const meta = {
         label: "Label",
         color: "coral",
         isLoading: false,
+        isOpaque: false,
         disabled: false,
         fullWidth: false,
         type: "button",
@@ -42,6 +43,10 @@ const meta = {
             },
         },
         isLoading: {
+            options: ["true", "false"],
+            control: "boolean",
+        },
+        isOpaque: {
             options: ["true", "false"],
             control: "boolean",
         },
@@ -116,6 +121,10 @@ const placeholder = {
     xl: <LabelPairedPlaceholderXlRegularIcon />,
 };
 
+const ExampleBasic: React.FC<React.ComponentProps<typeof Button>> = (args) => (
+    <Button {...args} />
+);
+
 export const ButtonWithLabelIconAtStart = (
     args: ComponentProps<typeof Button>,
 ) => (
@@ -144,6 +153,14 @@ export const ButtonDisabled = (args: ComponentProps<typeof Button>) => (
         {...args}
     />
 );
+
+export const ButtonDisabledOpaque = ExampleBasic.bind(this) as Story;
+ButtonDisabledOpaque.args = {
+    disabled: true,
+    isOpaque: true,
+    color: "black",
+};
+
 export const ButtonWithLoading = (args: ComponentProps<typeof Button>) => (
     <Button
         iconPosition="end"

--- a/lib/components/Button/base/index.tsx
+++ b/lib/components/Button/base/index.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from "react";
+import React, { forwardRef } from "react";
 import clsx from "clsx";
 import { ButtonProps } from "../types";
 import {
@@ -52,6 +52,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
             label,
             disabled,
             iconPosition = "start",
+            isOpaque,
             variant = "primary",
             iconButton = false,
             ...rest
@@ -63,55 +64,70 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         const labelSize = size === "md" ? "sm" : size === "lg" ? "md" : "xl";
         const DropdownIcon = dropdownIcons[size];
         const LoaderIcon = loaderIcons[size];
+        const Wrapper = isOpaque ? "span" : React.Fragment;
 
         return (
-            <button
-                className={clsx(
-                    "quill-button",
-                    iconButton ? iconButtonClass : ButtonSize[size],
-                    buttonColorClass,
-                    className,
-                    fullWidth && "quill-button__full-width",
-                )}
-                disabled={disabled}
-                data-state={selected ? "selected" : ""}
-                data-loading={isLoading}
-                ref={ref}
-                {...rest}
+            <Wrapper
+                {...(isOpaque
+                    ? {
+                          className: clsx(
+                              "quill-button",
+                              "quill-button__white-bg-wrapper",
+                              iconButton ? iconButtonClass : ButtonSize[size],
+                              fullWidth && "quill-button__full-width",
+                          ),
+                      }
+                    : {})}
             >
-                {iconPosition === "start" && icon && !isLoading && icon}
+                <button
+                    className={clsx(
+                        "quill-button",
+                        iconButton ? iconButtonClass : ButtonSize[size],
+                        buttonColorClass,
+                        className,
+                        fullWidth && "quill-button__full-width",
+                    )}
+                    disabled={disabled}
+                    data-state={selected ? "selected" : ""}
+                    data-loading={isLoading}
+                    ref={ref}
+                    {...rest}
+                >
+                    {iconPosition === "start" && icon && !isLoading && icon}
 
-                {isLoading && !disabled && (
-                    <LoaderIcon
-                        data-testid="button-loader"
-                        className="quill-button__loader-icon"
-                    />
-                )}
-                {children}
-                {label && !isLoading && (
-                    <span className="quill-button-label">
-                        {size === "sm" ? (
-                            <CaptionText color={color} bold>
-                                {label}
-                            </CaptionText>
-                        ) : (
-                            <Text size={labelSize} bold color={color}>
-                                {label}
-                            </Text>
-                        )}
-                    </span>
-                )}
-                {iconPosition === "end" && icon && !isLoading && icon}
-                {dropdown && DropdownIcon && !isLoading && (
-                    <DropdownIcon
-                        data-state={isDropdownOpen ? "open" : "close"}
-                        className={clsx(
-                            "quill-button__transform",
-                            isDropdownOpen && "quill-button__transform-rotate",
-                        )}
-                    />
-                )}
-            </button>
+                    {isLoading && !disabled && (
+                        <LoaderIcon
+                            data-testid="button-loader"
+                            className="quill-button__loader-icon"
+                        />
+                    )}
+                    {children}
+                    {label && !isLoading && (
+                        <span className="quill-button-label">
+                            {size === "sm" ? (
+                                <CaptionText color={color} bold>
+                                    {label}
+                                </CaptionText>
+                            ) : (
+                                <Text size={labelSize} bold color={color}>
+                                    {label}
+                                </Text>
+                            )}
+                        </span>
+                    )}
+                    {iconPosition === "end" && icon && !isLoading && icon}
+                    {dropdown && DropdownIcon && !isLoading && (
+                        <DropdownIcon
+                            data-state={isDropdownOpen ? "open" : "close"}
+                            className={clsx(
+                                "quill-button__transform",
+                                isDropdownOpen &&
+                                    "quill-button__transform-rotate",
+                            )}
+                        />
+                    )}
+                </button>
+            </Wrapper>
         );
     },
 );

--- a/lib/components/Button/button.scss
+++ b/lib/components/Button/button.scss
@@ -99,7 +99,10 @@
         &__full-width {
             width: 100%;
         }
-
+        &__white-bg-wrapper {
+            background-color: var(--core-color-solid-slate-50);
+            padding: unset;
+        }
         &-label {
             text-wrap: nowrap;
         }

--- a/lib/components/Button/types.ts
+++ b/lib/components/Button/types.ts
@@ -27,6 +27,7 @@ export interface ButtonProps extends Omit<ComponentProps<"button">, "ref"> {
     fullWidth?: boolean;
     isLoading?: boolean;
     iconPosition?: "start" | "end";
+    isOpaque?: boolean;
     className?: string;
     label?: ReactNode;
     children?: ReactNode;


### PR DESCRIPTION
## Changes:

#### Added an optional `isOpaque` prop to Button component which will add a white background to the button when we need it to be non-transparent (opaque) in disabled state.

This is necessary because in deriv-app consumer app, devs are currently forced to add the white background to every single `Button` because according to design in DTrader most of the buttons are floating and should be opaque when disabled.

Issue:
<img width="389" alt="Screenshot 2024-08-27 at 10 57 10 AM" src="https://github.com/user-attachments/assets/51fdef78-fd51-4186-a23d-f05294ee8e84">

Expected behavior:
<img width="389" alt="Screenshot 2024-08-27 at 10 57 48 AM" src="https://github.com/user-attachments/assets/239856c1-fea0-423f-ab53-37aa030c4a2f">
