### PR TITLE
[DTRA] Maryia/feat: improve opaque button wrapper styles

### DIFF
--- a/lib/components/Button/button.scss
+++ b/lib/components/Button/button.scss
@@ -102,6 +102,8 @@
         &__white-bg-wrapper {
             background-color: var(--core-color-solid-slate-50);
             padding: unset;
+            height: fit-content;
+            width: fit-content;
         }
         &-label {
             text-wrap: nowrap;

--- a/lib/components/Button/button.scss
+++ b/lib/components/Button/button.scss
@@ -96,14 +96,14 @@
             }
         }
 
-        &__full-width {
-            width: 100%;
-        }
         &__white-bg-wrapper {
             background-color: var(--core-color-solid-slate-50);
             padding: unset;
             height: fit-content;
             width: fit-content;
+        }
+        &__full-width {
+            width: 100%;
         }
         &-label {
             text-wrap: nowrap;


### PR DESCRIPTION
## Changes:

#### Made the opaque button wrapper always fit in the content (button) in those cases when the button size is getting overridden in the consumer app CSS.