### PR TITLE
DTRA-2157 / Kate / Input component fix

### DIFF
--- a/lib/components/Input/base/index.tsx
+++ b/lib/components/Input/base/index.tsx
@@ -62,6 +62,7 @@ export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
     triggerActionIcon?: ReactNode;
     fieldMarker?: boolean;
     showInputButton?: boolean;
+    shouldRound?: boolean;
     button_position?: TRightOrBottom;
     inputButton?: ReactNode;
     leftPlaceholder?: string;
@@ -121,6 +122,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
             fieldMarker = false,
             required = false,
             showInputButton,
+            shouldRound = true,
             inputButton: InputButton,
             addOn,
             formatProps,
@@ -199,7 +201,11 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
             }
 
             if (decimals) {
-                inputValue = getFormatValue(inputValue, decimals).toString();
+                inputValue = getFormatValue(
+                    inputValue,
+                    decimals,
+                    shouldRound,
+                ).toString();
             }
 
             if (customType) {

--- a/lib/components/Input/text-field-addon/text-field-addon.stories.tsx
+++ b/lib/components/Input/text-field-addon/text-field-addon.stories.tsx
@@ -27,6 +27,7 @@ const meta = {
         fieldMarker: false,
         required: false,
         show_counter: false,
+        shouldRound: true,
         fillAddonBorderColor:
             "var(--semantic-color-slate-solid-surface-frame-mid)",
     },
@@ -73,6 +74,9 @@ const meta = {
             table: {
                 defaultValue: { summary: "neutral" },
             },
+        },
+        shouldRound: {
+            control: "boolean",
         },
         variant: {
             control: {
@@ -133,5 +137,14 @@ export const LabelledlessFill: Story = {
         placeholder: "Placeholder",
         variant: "fill",
         message: message,
+    },
+};
+export const WithoutRounding: Story = {
+    args: {
+        type: "number",
+        allowDecimals: true,
+        decimals: 2,
+        message: message,
+        shouldRound: false,
     },
 };

--- a/lib/components/Input/text-field-with-steppers/text-field-with-steppers.stories.tsx
+++ b/lib/components/Input/text-field-with-steppers/text-field-with-steppers.stories.tsx
@@ -44,6 +44,7 @@ const meta = {
         type: "number",
         inputSize: "md",
         status: "neutral",
+        shouldRound: true,
         disabled: false,
         variant: "outline",
         textAlignment: "left",
@@ -116,6 +117,9 @@ const meta = {
             },
         },
         noStatusIcon: {
+            control: "boolean",
+        },
+        shouldRound: {
             control: "boolean",
         },
     },
@@ -193,4 +197,9 @@ ErrorMessageTextFieldWithIcons.args = {
     status: status.error,
     message,
     rightIcon: <StandaloneTriangleExclamationBoldIcon iconSize="sm" />,
+};
+
+export const TextFieldWithoutRounding = Template.bind({}) as Story;
+TextFieldWithoutRounding.args = {
+    shouldRound: false,
 };

--- a/lib/components/Input/text-field/text-field.stories.tsx
+++ b/lib/components/Input/text-field/text-field.stories.tsx
@@ -41,6 +41,7 @@ const meta = {
         fieldMarker: false,
         required: false,
         show_counter: false,
+        shouldRound: true,
         allowDecimals: false,
     },
     argTypes: {
@@ -87,6 +88,9 @@ const meta = {
             table: {
                 defaultValue: { summary: "neutral" },
             },
+        },
+        shouldRound: {
+            control: "boolean",
         },
         variant: {
             control: {
@@ -199,5 +203,14 @@ export const StatusMessageWithCharacterCounter: Story = {
         message,
         show_counter: true,
         maxLength: 15,
+    },
+};
+
+export const WithoutRounding: Story = {
+    args: {
+        type: "number",
+        allowDecimals: true,
+        decimals: 2,
+        shouldRound: false,
     },
 };

--- a/lib/utils/common-utils.ts
+++ b/lib/utils/common-utils.ts
@@ -29,7 +29,11 @@ export const reactNodeToString = (reactNode: React.ReactNode): string => {
 const toFixedWithoutRounding = (value: number, decimals: number) =>
     Math.floor(Math.pow(10, decimals) * value) / Math.pow(10, decimals);
 
-export const getFormatValue = (value: number | string, decimals: number) => {
+export const getFormatValue = (
+    value: number | string,
+    decimals: number,
+    shouldRound = true,
+) => {
     if (!value) return value;
 
     const inputValue = value.toString();
@@ -42,5 +46,7 @@ export const getFormatValue = (value: number | string, decimals: number) => {
 
     if (isNaN(numValue)) return value;
 
-    return toFixedWithoutRounding(numValue, decimals);
+    return shouldRound
+        ? numValue.toFixed(decimals)
+        : toFixedWithoutRounding(numValue, decimals);
 };

--- a/lib/utils/common-utils.ts
+++ b/lib/utils/common-utils.ts
@@ -26,6 +26,9 @@ export const reactNodeToString = (reactNode: React.ReactNode): string => {
     return string;
 };
 
+const toFixedWithoutRounding = (value: number, decimals: number) =>
+    Math.floor(Math.pow(10, decimals) * value) / Math.pow(10, decimals);
+
 export const getFormatValue = (value: number | string, decimals: number) => {
     if (!value) return value;
 
@@ -39,5 +42,5 @@ export const getFormatValue = (value: number | string, decimals: number) => {
 
     if (isNaN(numValue)) return value;
 
-    return numValue.toFixed(decimals);
+    return toFixedWithoutRounding(numValue, decimals);
 };


### PR DESCRIPTION
Changed the way how the value is truncate in input. Previously toFixed was used and the problem that it round the value: for 2 decimals ---> 5.6**7** ---> user type '8' ---> 5.678 ---> 5.678.toFixed(2) --> 5.6**8**.
New behaviour: the cut off will not round the value: for 2 decimals ---> 5.6**7** ---> user type '8' ---> 5.678 --->  toFixedWithoutRounding(5.678, 2) --> 5.6**7**.

Video explanation of the bug: 

https://github.com/user-attachments/assets/ee50defe-5cfc-4bb5-9c87-7ece08574233
