### PR TITLE
Akmal / fix: put snackbar behind modal

### DIFF
--- a/lib/components/Snackbar/snackbar.scss
+++ b/lib/components/Snackbar/snackbar.scss
@@ -16,7 +16,7 @@
     background: var(--component-snackbar-bg);
     box-shadow: var(--core-elevation-shadow-330);
     position: fixed;
-    z-index: 999;
+    z-index: 149;
     bottom: -16px;
     transition: bottom var(--motion-duration-snappy)
         var(--motion-easing-inandout);


### PR DESCRIPTION
This fix adjusts the z-index of the snackbar to ensure it appears behind modal dialogs, improving visual hierarchy and clarity.

1. Z-Index Adjustment: Modify the snackbar’s z-index so that it remains behind open modals, preventing visual overlap issues.
2. UI Consistency: Ensure that the snackbar does not obstruct modal content, enhancing focus on the modal dialog when active.
3. Improved User Experience: Maintain a clear and organized visual structure, allowing users to interact with modals without distraction.

This fix enhances the user interface by ensuring that the snackbar is appropriately layered behind modals.
