### PR TITLE
DTRA-2171 / Kate / Fix: delay in snackbar

### DIFF
--- a/lib/components/Snackbar/snackbar.stories.tsx
+++ b/lib/components/Snackbar/snackbar.stories.tsx
@@ -261,3 +261,11 @@ SnackbarWithRemoveCallback.args = {
     message: "Please, open the console",
     onSnackbarRemove: () => console.log("onSnackbarRemove was called"),
 };
+
+export const SnackbarWithLongDelay = Template.bind(this) as Story;
+SnackbarWithLongDelay.args = {
+    ...meta.args,
+    hasFixedHeight: false,
+    message: "This is a snackbar with prolonged delay",
+    delay: 10000,
+};

--- a/lib/components/Snackbar/snackbar.tsx
+++ b/lib/components/Snackbar/snackbar.tsx
@@ -63,6 +63,7 @@ export const Snackbar = ({
             (timerRef.current = snackbarDelayedRemove({
                 id,
                 onSnackbarRemove,
+                delay,
             }));
 
         return () => {


### PR DESCRIPTION
The delay prop was not passed to the function for removing the snackbar, hence, it was not working. Fixed, by passing it.
Added a story for functionality demonstration.