### PR TITLE
Akmal / feat: remove disappearance for failed snackbars with close button

### DIFF
--- a/lib/components/Snackbar/snackbar.tsx
+++ b/lib/components/Snackbar/snackbar.tsx
@@ -59,22 +59,25 @@ export const Snackbar = ({
     const ref = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
-        id &&
-            (timerRef.current = snackbarDelayedRemove({
-                id,
-                onSnackbarRemove,
-                delay,
-            }));
+        if (id) {
+            if (status === "neutral" || !hasCloseButton || delay !== undefined) {
+                timerRef.current = snackbarDelayedRemove({
+                    id,
+                    onSnackbarRemove,
+                    delay: delay || 4000,
+                });
+            }
+        }
 
         return () => {
-            clearTimeout(timerRef.current ?? "");
+            if (timerRef.current) clearTimeout(timerRef.current);
         };
-    }, [message]);
+    }, [message, status, hasCloseButton, delay, id, onSnackbarRemove]);
 
     const handleClose = () => {
         onCloseAction?.();
-        if (timerRef) clearTimeout(timerRef.current ?? "");
-        id && snackbarDelayedRemove({ id, onSnackbarRemove, delay: 100 });
+        if (timerRef.current) clearTimeout(timerRef.current);
+        id && removeSnackbar(id, onSnackbarRemove);
     };
 
     const handleActionClick = () => {


### PR DESCRIPTION
This feature prevents failed snackbars with a close button from disappearing automatically, giving users control over dismissing error messages.

1. Persistent Snackbars: Ensure failed snackbars with a close button remain visible until manually dismissed by the user.
2. Enhanced Feedback: Allow users to review error details without the risk of the message disappearing prematurely.
3. Improved Usability: Provide a more reliable error-handling experience by keeping important messages accessible.

This change improves error visibility and user control over dismissing failed snackbars with a close button.
